### PR TITLE
Set the __CARGO_TEST_ROOT env variable for during tests.

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -375,6 +375,7 @@ impl Project {
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .current_dir(self.root())
+                .env("__CARGO_TEST_ROOT", self.root())
                 .spawn()
                 .unwrap(),
         )


### PR DESCRIPTION
Fixes fallout from https://github.com/rust-lang/rust/pull/53586 (confirmed locally).