### PR TITLE
Support InitializationOptions.settings

### DIFF
--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -1186,8 +1186,7 @@ pub mod test {
                 true,
             );
 
-            let init_options = InitializationOptions::default();
-            ctx.init(&init_options, output);
+            ctx.init(InitializationOptions::default(), output);
             ctx.build(&project_dir, BuildPriority::Immediate, output);
 
             TooltipTestHarness {

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -309,11 +309,16 @@ impl InitActionContext {
     fn init<O: Output>(&self, init_options: InitializationOptions, out: &O) {
         let current_project = self.current_project.clone();
 
-        if let Some(config) = init_options.settings.map(|s| s.rust) {
-            self.config.lock().unwrap().update(config);
-        }
+        let needs_inference = {
+            let mut config = self.config.lock().unwrap();
 
-        if self.config.lock().unwrap().needs_inference() {
+            if let Some(init_config) = init_options.settings.map(|s| s.rust) {
+                config.update(init_config);
+            }
+            config.needs_inference()
+        };
+
+        if needs_inference {
             let config = Arc::clone(&self.config);
             // Spawn another thread since we're shelling out to Cargo and this can
             // cause a non-trivial amount of time due to disk access

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,7 +114,7 @@ impl<T> AsRef<T> for Inferrable<T> {
 }
 
 /// RLS configuration options.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[allow(missing_docs)]
 #[serde(default)]
 pub struct Config {

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -21,6 +21,7 @@ use rls_span as span;
 use serde_derive::{Deserialize, Serialize};
 use url::Url;
 
+use crate::config;
 use crate::actions::hover;
 
 pub use languageserver_types::notification::Notification as LSPNotification;
@@ -256,16 +257,24 @@ impl RangeExt for Range {
     }
 }
 
+/// `DidChangeConfigurationParams.settings` payload reading the { rust: {...} } bit.
+#[derive(Debug, Deserialize)]
+pub struct ChangeConfigSettings {
+    pub rust: config::Config,
+}
+
 /* -----------------  JSON-RPC protocol types ----------------- */
 
 /// Supported initialization options that can be passed in the `initialize`
 /// request, under `initialization_options` key. These are specific to the RLS.
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct InitializationOptions {
     /// Should the build not be triggered immediately after receiving `initialize`
     pub omit_init_build: bool,
     pub cmd_run: bool,
+    /// `DidChangeConfigurationParams.settings` payload for upfront configuration.
+    pub settings: Option<ChangeConfigSettings>,
 }
 
 impl Default for InitializationOptions {
@@ -273,6 +282,7 @@ impl Default for InitializationOptions {
         InitializationOptions {
             omit_init_build: false,
             cmd_run: false,
+            settings: None,
         }
     }
 }

--- a/src/test/harness.rs
+++ b/src/test/harness.rs
@@ -95,7 +95,7 @@ impl Environment {
     crate fn mock_server(
         &mut self,
         messages: Vec<String>,
-    ) -> (ls_server::LsService<RecordOutput>, LsResultList) {
+    ) -> (ls_server::LsService<RecordOutput>, LsResultList, Arc<Mutex<Config>>) {
         let analysis = Arc::new(AnalysisHost::new(Target::Debug));
         let vfs = Arc::new(Vfs::new());
         let config = Arc::new(Mutex::new(self.config.take().unwrap()));
@@ -103,8 +103,9 @@ impl Environment {
         let output = RecordOutput::new();
         let results = output.output.clone();
         (
-            ls_server::LsService::new(analysis, vfs, config, reader, output),
+            ls_server::LsService::new(analysis, vfs, Arc::clone(&config), reader, output),
             results,
+            config,
         )
     }
 }

--- a/src/test/lens.rs
+++ b/src/test/lens.rs
@@ -6,7 +6,6 @@ use url::Url;
 
 use crate::{
     actions::requests,
-    lsp_data::InitializationOptions,
     server as ls_server,
     test::{
         harness::{compare_json, expect_message, expect_series, Environment, ExpectedMessage},
@@ -16,6 +15,8 @@ use crate::{
 
 #[test]
 fn test_lens_run() {
+    use serde_json::json;
+
     let mut env = Environment::new("lens_run");
 
     let source_file_path = Path::new("src").join("main.rs");
@@ -29,10 +30,7 @@ fn test_lens_run() {
         initialize_with_opts(
             0,
             root_path,
-            Some(InitializationOptions {
-                omit_init_build: false,
-                cmd_run: true,
-            }),
+            Some(json!({ "cmdRun": true })),
         ).to_string(),
         request::<requests::CodeLensRequest>(
             100,
@@ -42,7 +40,7 @@ fn test_lens_run() {
         ).to_string(),
     ];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -42,7 +42,6 @@ fn initialize_with_opts(
     root_path: Option<String>,
     initialization_options: Option<serde_json::Value>,
 ) -> Request<ls_server::InitializeRequest> {
-    // let init_opts = initialization_options.map(|val| serde_json::to_value(val).unwrap());
     let params = InitializeParams {
         process_id: None,
         root_path,

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -23,7 +23,6 @@ use self::harness::{
     compare_json, expect_message, expect_series, src, Environment, ExpectedMessage, RecordOutput,
 };
 
-use crate::lsp_data::InitializationOptions;
 use languageserver_types::*;
 
 use env_logger;
@@ -41,14 +40,14 @@ fn initialize(id: usize, root_path: Option<String>) -> Request<ls_server::Initia
 fn initialize_with_opts(
     id: usize,
     root_path: Option<String>,
-    initialization_options: Option<InitializationOptions>,
+    initialization_options: Option<serde_json::Value>,
 ) -> Request<ls_server::InitializeRequest> {
-    let init_opts = initialization_options.map(|val| serde_json::to_value(val).unwrap());
+    // let init_opts = initialization_options.map(|val| serde_json::to_value(val).unwrap());
     let params = InitializeParams {
         process_id: None,
         root_path,
         root_uri: None,
-        initialization_options: init_opts,
+        initialization_options,
         capabilities: ClientCapabilities {
             workspace: None,
             text_document: None,
@@ -104,7 +103,7 @@ fn test_shutdown() {
         blocking_request::<ShutdownRequest>(1, ()).to_string(),
     ];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -149,7 +148,7 @@ fn test_goto_def() {
         ).to_string(),
     ];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -199,7 +198,7 @@ fn test_hover() {
         ).to_string(),
     ];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -282,7 +281,7 @@ fn test_hover_after_src_line_change() {
         ).to_string(),
     ];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -344,7 +343,7 @@ fn test_workspace_symbol() {
     ];
 
     env.with_config(|c| c.cfg_test = true);
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -400,7 +399,7 @@ fn test_workspace_symbol_duplicates() {
     ];
 
     env.with_config(|c| c.cfg_test = true);
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -466,7 +465,7 @@ fn test_find_all_refs() {
     ];
 
     env.with_config(|c| c.cfg_test = true);
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -523,7 +522,7 @@ fn test_find_all_refs_no_cfg_test() {
         ).to_string(),
     ];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -561,7 +560,7 @@ fn test_borrow_error() {
     let messages =
         vec![initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string()];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -608,7 +607,7 @@ fn test_highlight() {
         ).to_string(),
     ];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -662,7 +661,7 @@ fn test_rename() {
         ).to_string(),
     ];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -718,7 +717,7 @@ fn test_reformat() {
         ).to_string(),
     ];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -779,7 +778,7 @@ fn test_reformat_with_range() {
         ).to_string(),
     ];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
 
     // Initialize and build.
     assert_eq!(
@@ -813,7 +812,7 @@ fn test_multiple_binaries() {
         vec![initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string()];
 
     env.with_config(|c| c.build_bin = Inferrable::Specified(Some("bin2".to_owned())));
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -866,7 +865,7 @@ fn test_multiple_binaries() {
 //         }).to_string(),
 //     ];
 
-//     let (mut server, results) = env.mock_server(messages);
+//     let (mut server, results, ..) = env.mock_server(messages);
 //     // Initialize and build.
 //     assert_eq!(ls_server::LsService::handle_message(&mut server),
 //                ls_server::ServerStateChange::Continue);
@@ -896,7 +895,7 @@ fn test_bin_lib_project() {
         c.cfg_test = true;
         c.build_bin = Inferrable::Specified(Some("bin_lib".into()));
     });
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -942,7 +941,7 @@ fn test_bin_lib_project() {
 //         c.build_lib = Inferrable::Specified(false);
 //         c.build_bin = Inferrable::Specified(Some("bin_lib".into()));
 //     });
-//     let (mut server, results) = env.mock_server(messages);
+//     let (mut server, results, ..) = env.mock_server(messages);
 //     // Initialize and build.
 //     assert_eq!(ls_server::LsService::handle_message(&mut server),
 //                ls_server::ServerStateChange::Continue);
@@ -963,7 +962,7 @@ fn test_bin_lib_project() {
 //         initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
 //     ];
 
-//     let (mut server, results) = env.mock_server(messages);
+//     let (mut server, results, ..) = env.mock_server(messages);
 //     // Initialize and build.
 //     assert_eq!(ls_server::LsService::handle_message(&mut server),
 //                ls_server::ServerStateChange::Continue);
@@ -985,7 +984,7 @@ fn test_infer_lib() {
     let messages =
         vec![initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string()];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -1021,7 +1020,7 @@ fn test_infer_bin() {
     let messages =
         vec![initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string()];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -1057,7 +1056,7 @@ fn test_infer_custom_bin() {
     let messages =
         vec![initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string()];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -1088,19 +1087,19 @@ fn test_infer_custom_bin() {
 
 #[test]
 fn test_omit_init_build() {
+    use serde_json::json;
+
     let mut env = Environment::new("common");
 
     let root_path = env.cache.abs_path(Path::new("."));
     let root_path = root_path.as_os_str().to_str().map(|x| x.to_owned());
-    let init_options = Some(InitializationOptions {
-        omit_init_build: true,
-        cmd_run: true,
+    let init_options = json!({
+        "omitInitBuild": true,
+        "cmdRun": true
     });
-    let initialize = initialize_with_opts(0, root_path, init_options);
+    let initialize = initialize_with_opts(0, root_path, Some(init_options));
 
-    let messages = vec![initialize.to_string()];
-
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(vec![initialize.to_string()]);
 
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -1111,6 +1110,46 @@ fn test_omit_init_build() {
         results,
         ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
     );
+}
+
+#[test]
+fn test_init_with_configuration() {
+    use serde_json::json;
+
+    let mut env = Environment::new("common");
+
+    let root_path = env.cache.abs_path(Path::new("."));
+    let root_path = root_path.as_os_str().to_str().map(|x| x.to_owned());
+    let init_options = json!({
+        "settings": {
+            "rust": {
+                "features": ["some_feature"],
+                "all_targets": false
+            }
+        }
+    });
+
+    let initialize = initialize_with_opts(0, root_path, Some(init_options));
+
+    let (mut server, results, config) = env.mock_server(vec![initialize.to_string()]);
+
+    assert!(
+        &config.lock().unwrap().features.is_empty(),
+        "Default config should have no explicit features enabled"
+    );
+
+    assert_eq!(
+        ls_server::LsService::handle_message(&mut server),
+        ls_server::ServerStateChange::Continue
+    );
+    expect_message(
+        &mut server,
+        results,
+        ExpectedMessage::new(Some(0)).expect_contains("capabilities"),
+    );
+
+    assert_eq!(&config.lock().unwrap().features, &["some_feature"]);
+    assert_eq!(config.lock().unwrap().all_targets, false);
 }
 
 #[test]
@@ -1194,7 +1233,7 @@ fn test_find_impls() {
         //     ).to_string(),
     ];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -1256,7 +1295,7 @@ fn test_features() {
         vec![initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string()];
 
     env.with_config(|c| c.features = vec!["foo".to_owned()]);
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -1295,7 +1334,7 @@ fn test_all_features() {
         vec![initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string()];
 
     env.with_config(|c| c.all_features = true);
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -1322,7 +1361,7 @@ fn test_no_default_features() {
         c.no_default_features = true;
         c.features = vec!["foo".to_owned(), "bar".to_owned()]
     });
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -1362,7 +1401,7 @@ fn test_no_default_features() {
 //         initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string()
 //     ];
 //
-//     let (mut server, results) = env.mock_server(messages);
+//     let (mut server, results, ..) = env.mock_server(messages);
 //     // Initialize and build.
 //     assert_eq!(ls_server::LsService::handle_message(&mut server),
 //                ls_server::ServerStateChange::Continue);
@@ -1451,7 +1490,7 @@ fn test_deglob() {
         ).to_string(),
     ];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -1606,7 +1645,7 @@ fn test_all_targets() {
         c.all_targets = true;
         c.cfg_test = true;
     });
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
     // Initialize and build.
     assert_eq!(
         ls_server::LsService::handle_message(&mut server),
@@ -1672,7 +1711,7 @@ fn ignore_uninitialized_notification() {
         initialize(1, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
     ];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
 
     // Ignore notification
     assert_eq!(
@@ -1718,7 +1757,7 @@ fn fail_uninitialized_request() {
         initialize(1, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
     ];
 
-    let (mut server, results) = env.mock_server(messages);
+    let (mut server, results, ..) = env.mock_server(messages);
 
     // Return error response to pre `initialize` request, keep running.
     assert_eq!(
@@ -1763,7 +1802,7 @@ fn fail_uninitialized_request() {
 //         initialize(0, root_path.as_os_str().to_str().map(|x| x.to_owned())).to_string(),
 //     ];
 
-//     let (mut server, results) = env.mock_server(messages);
+//     let (mut server, results, ..) = env.mock_server(messages);
 //     // Initialize and build.
 //     assert_eq!(
 //         ls_server::LsService::handle_message(&mut server),


### PR DESCRIPTION
Allows configuration at startup via `initializationOptions.settings` (mirroring _DidChangeConfigurationParams.settings_).

* Removed serialize implementations preferring to test with `json!` (also Config serialize impl wasn't working fully).
* Add warn logging when initialization options fail to deserialize. _Adding unknown options warnings in future would also be nice_.

Resolves #1026 