### PR TITLE
Fallback to racer definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Currently we accept the following options:
   features
 * `racer_completion` (`bool`, defaults to `true`) enables code completion using
   racer (which is, at the moment, our only code completion backend). Also enables
-  hover tooltips to fall back to racer when save-analysis data is unavailable.
+  hover tooltips & go-to-definition to fall back to racer when save-analysis data is unavailable.
 * `clippy_preference` (`String`, defaults to `"opt-in"`) controls eagerness of clippy
   diagnostics when available. Valid values are _(case-insensitive)_:
   - `"off"` Disable clippy lints.

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -24,8 +24,6 @@ use url::Url;
 
 use crate::actions::hover;
 use crate::actions::run::collect_run_actions;
-use crate::actions::work_pool;
-use crate::actions::work_pool::WorkDescription;
 use crate::build::Edition;
 use crate::lsp_data;
 use crate::lsp_data::*;
@@ -203,45 +201,27 @@ impl RequestAction for Definition {
         let span = ctx.convert_pos_to_span(file_path.clone(), params.position);
         let analysis = ctx.analysis.clone();
 
-        // If configured start racer concurrently and fallback to racer result
-        let racer_receiver = {
-            if ctx.config.lock().unwrap().goto_def_racer_fallback {
-                Some(work_pool::receive_from_thread(
-                    move || {
-                        let cache = ctx.racer_cache();
-                        let session = ctx.racer_session(&cache);
-                        let location = pos_to_racer_location(params.position);
-
-                        racer::find_definition(file_path, location, &session)
-                            .and_then(|rm| location_from_racer_match(&rm))
-                    },
-                    WorkDescription("textDocument/definition-racer"),
-                ))
-            } else {
-                None
-            }
-        };
-
         match analysis.goto_def(&span) {
             Ok(out) => {
                 let result = vec![ls_util::rls_to_location(&out)];
                 trace!("goto_def (compiler): {:?}", result);
                 Ok(result)
             }
-            _ => match racer_receiver {
-                Some(receiver) => match receiver.recv() {
-                    Ok(Some(r)) => {
-                        trace!("goto_def (Racer): {:?}", r);
-                        Ok(vec![r])
-                    }
-                    Ok(None) => {
-                        trace!("goto_def (Racer): None");
-                        Ok(vec![])
-                    }
-                    _ => Self::fallback_response(),
-                },
-                _ => Self::fallback_response(),
-            },
+            // If analysis failed & `racer_completion` is enabled try racer
+            _ if ctx.config.lock().unwrap().racer_completion => {
+                let cache = ctx.racer_cache();
+                let session = ctx.racer_session(&cache);
+                let location = pos_to_racer_location(params.position);
+
+                let r = racer::find_definition(file_path, location, &session)
+                    .and_then(|rm| location_from_racer_match(&rm))
+                    .map(|l| vec![l])
+                    .unwrap_or_default();
+
+                trace!("goto_def (Racer): {:?}", r);
+                Ok(r)
+            }
+            _ => Self::fallback_response(),
         }
     }
 }

--- a/src/build/plan.rs
+++ b/src/build/plan.rs
@@ -53,6 +53,7 @@ crate enum WorkStatus {
     Execute(JobQueue),
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 crate enum BuildPlan {
     External(ExternalPlan),

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,7 +127,6 @@ pub struct Config {
     pub unstable_features: bool,
     pub wait_to_build: Option<u64>,
     pub show_warnings: bool,
-    pub goto_def_racer_fallback: bool,
     /// Clear the RUST_LOG env variable before calling rustc/cargo? Default: true
     pub clear_env_rust_log: bool,
     /// Build the project only when a file got saved and not on file change. Default: false
@@ -140,7 +139,10 @@ pub struct Config {
     pub no_default_features: bool,
     pub jobs: Option<u32>,
     pub all_targets: bool,
-    /// Enable use of racer for `textDocument/completion` requests
+    /// Enable use of racer for `textDocument/completion` requests.
+    ///
+    /// Enabled also enables racer fallbacks for hover & go-to-definition functionality
+    /// if rustc analysis should fail.
     pub racer_completion: bool,
     #[serde(deserialize_with = "deserialize_clippy_preference")]
     pub clippy_preference: ClippyPreference,
@@ -177,7 +179,6 @@ impl Default for Config {
             unstable_features: false,
             wait_to_build: None,
             show_warnings: true,
-            goto_def_racer_fallback: false,
             clear_env_rust_log: true,
             build_on_save: false,
             use_crate_blacklist: true,


### PR DESCRIPTION
I've been having a look at handling lsp in out-of-project rust files, like dependencies, for ide-rust which got me more interested in this. From the discussions in #1139 & #1106 I think we got fairly close to consensus.

* Runs racer find_definition if analysis goto has failed and `racer_completion` config is enabled. This brings the functionality in line with hover _(now in both cases racer calls are lazy)_.
* Removed `goto_def_racer_fallback` config.
* _Minor: Ignore clippy large enum lint in `BuildPlan`._

I think reusing `racer_completion` config is desirable, as the only known reason to disable this is when racer has critical performance issues with a project. In these cases we'd also not want any racer-fallbacks to run. In other cases where analysis works these fallbacks have no cost, so again I don't see an advantage in having a separate config.

Resolves #1106 
Resolves #1139