### PR TITLE
DONTMERGEME: Check if rls-analysis branch fixes tooltip tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,7 +1153,7 @@ dependencies = [
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-analysis 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-analysis 0.16.9 (git+https://github.com/Xanewok/rls-analysis?branch=illegal-racing)",
  "rls-blacklist 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-data 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-rustc 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1174,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "rls-analysis"
 version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/Xanewok/rls-analysis?branch=illegal-racing#3dc74302920bdf2a2feea44584180a946500e568"
 dependencies = [
  "derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fst 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1909,7 +1909,7 @@ dependencies = [
 "checksum regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
 "checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
-"checksum rls-analysis 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2d75da3cfdc01707f5a510e1e93bd405f00eb210bc039925e54c78990c286b38"
+"checksum rls-analysis 0.16.9 (git+https://github.com/Xanewok/rls-analysis?branch=illegal-racing)" = "<none>"
 "checksum rls-blacklist 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ce1fdac03e138c4617ff87b194e1ff57a39bb985a044ccbd8673d30701e411"
 "checksum rls-data 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a209ce46bb52813cbe0786a7baadc0c1a3f5543ef93f179eda3b841ed72cf2e"
 "checksum rls-rustc 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9dba7390427aefa953608429701e3665192ca810ba8ae09301e001b7c7bed0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ categories = ["development-tools"]
 
 build = "build.rs"
 
+[patch.crates-io]
+rls-analysis = { git = "https://github.com/Xanewok/rls-analysis", branch = "illegal-racing" }
+
 [dependencies]
 cargo = { git = "https://github.com/rust-lang/cargo", rev = "b3d0b2e545b61d4cd08096911724b7d49d213f73" }
 cargo_metadata = "0.6"


### PR DESCRIPTION
https://github.com/rust-dev-tools/rls-analysis/pull/159
([branch](https://github.com/Xanewok/rls-analysis/tree/illegal-racing))