### PR TITLE
Fix reformat_with_range test in CI for Windows

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -796,9 +796,11 @@ fn test_reformat_with_range() {
         ls_server::LsService::handle_message(&mut server),
         ls_server::ServerStateChange::Continue
     );
+    let newline = if cfg!(windows) { r#"\r\n"# } else { r#"\n"# };
+    let formatted = r#"newText":"// Copyright 2017 The Rust Project Developers. See the COPYRIGHT\n// file at the top-level directory of this distribution and at\n// http://rust-lang.org/COPYRIGHT.\n//\n// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms.\n\npub fn main() {\n    let world1 = \"world\";\n    println!(\"Hello, {}!\", world1);\n    let world2 = \"world\";\n    println!(\"Hello, {}!\", world2);\n    let world3 = \"world\";\n    println!(\"Hello, {}!\", world3);\n}\n"#;
     expect_message(&mut server, results,
         ExpectedMessage::new(Some(42)).expect_contains(r#"{"start":{"line":0,"character":0},"end":{"line":15,"character":5}}"#)
-            .expect_contains(r#"newText":"// Copyright 2017 The Rust Project Developers. See the COPYRIGHT\n// file at the top-level directory of this distribution and at\n// http://rust-lang.org/COPYRIGHT.\n//\n// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or\n// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license\n// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your\n// option. This file may not be copied, modified, or distributed\n// except according to those terms.\n\npub fn main() {\n    let world1 = \"world\";\n    println!(\"Hello, {}!\", world1);\n    let world2 = \"world\";\n    println!(\"Hello, {}!\", world2);\n    let world3 = \"world\";\n    println!(\"Hello, {}!\", world3);\n}\n"#)
+            .expect_contains(&formatted.replace(r#"\n"#, newline))
     );
 }
 

--- a/test_data/reformat_with_range/rustfmt.toml
+++ b/test_data/reformat_with_range/rustfmt.toml
@@ -1,2 +1,4 @@
-newline_style = "Unix"
+# Work around Travis checking files out with autocrlf=true
+# https://travis-ci.community/t/files-in-checkout-have-eol-changed-from-lf-to-crlf/349
+newline_style = "Native"
 


### PR DESCRIPTION
Files in checkout have EOL changed from LF to CRLF, see
https://travis-ci.community/t/files-in-checkout-have-eol-changed-from-lf-to-crlf/349.

Now only `test_tooltip` fails with
```
test actions::hover::test::test_tooltip ... FAILED
error: unexpected close delimiter: `}`
 --> <stdin>:5:1
  |
5 | }
  | ^ unexpected close delimiter
```