### PR TITLE
Improve caching in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ branches:
 cache:
   cargo: true
   timeout: 300
+# Quicker to fetch that during the build than to transmit as part of the cache
+before_cache:
+- rm -rf /home/travis/.cargo/registry
 os:
 - linux
 - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ branches:
   except:
   - staging.tmp
   - trying.tmp
-cache: cargo
+cache:
+  cargo: true
+  timeout: 300
 os:
 - linux
 - osx


### PR DESCRIPTION
It seems our cache pushing takes a wee bit more than 180s, which exceeds the timeout. Bumping it to 300s doesn't add too much time and thanks to that we wouldn't need to rebuild dependencies from scratch every time.
Also, it doesn't make sense to cache the registry itself, since it's also transmitted via network but this doesn't add the (un)packing overhead. (See also https://levans.fr/rust_travis_cache.html)