### PR TITLE
Fix hover infinite loop

### DIFF
--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -142,7 +142,7 @@ pub fn extract_docs(
             };
         }
 
-        if in_meta {
+        if !hit_top && in_meta {
             // Ignore milti-line attributes
             trace!(
                 "extract_docs: ignoring multi-line attribute, next_row: {:?}, up: {}, in_meta: {}",


### PR DESCRIPTION
`extract_docs` if-continue could cause endless looping if moving up & top line meta.

_after fix:_
![](https://user-images.githubusercontent.com/2331607/49618673-54152680-f9b1-11e8-80aa-43c6da1b3c75.png)


Fixes #1168