### PR TITLE
Improve hover test_tooltip tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ install: |
 script:
 - cargo build -v
 - cargo test -v
+- cargo test test_tooltip_std -- --ignored
+
 env:
   global:
-  - RUSTFLAGS=--cfg=enable_tooltip_tests
   - RUST_BACKTRACE=1
   - RLS_TEST_WAIT_FOR_AGES=1
   - CARGO_INCREMENTAL=0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,11 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "either"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1141,7 @@ dependencies = [
  "cargo_metadata 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy_lints 0.0.212 (git+https://github.com/rust-lang/rust-clippy?rev=a3c77f6ad1c1c185e561e9cd7fdec7db569169d1)",
  "crossbeam-channel 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1818,6 +1824,7 @@ dependencies = [
 "checksum derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6ca414e896ae072546f4d789f452daaecf60ddee4c9df5dc6d5936d769e3d87c"
 "checksum derive_more 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f57d78cf3bd45270dad4e70c21ec77a960b36c7a841ff9db76aaa775a8fb871"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
+"checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum ena 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f56c93cc076508c549d9bb747f79aa9b4eb098be7b8cad8830c3137ef52d1e00"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ toml = "0.4"
 # for more information.
 rustc-workspace-hack = "1.0.0"
 
+[dev-dependencies]
+difference = "2"
+
 [build-dependencies]
 rustc_tools_util = { git = "https://github.com/rust-lang/rust-clippy", rev = "a3c77f6ad1c1c185e561e9cd7fdec7db569169d1" }
 

--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -2030,8 +2030,6 @@ pub mod test {
     }
 
     #[test]
-    // doesn't work in the rust-lang/rust repo, enable on CI
-    #[cfg_attr(not(enable_tooltip_tests), ignore)]
     fn test_tooltip() -> Result<(), Box<dyn std::error::Error>> {
         use self::test::{LineOutput, Test, TooltipTestHarness};
         use std::env;
@@ -2090,6 +2088,43 @@ pub mod test {
             Test::new("test_tooltip_mod_use_external.rs", 12, 12),
             Test::new("test_tooltip_mod_use_external.rs", 14, 12),
             Test::new("test_tooltip_mod_use_external.rs", 15, 12),
+        ];
+
+        let cwd = env::current_dir()?;
+        let out = LineOutput::default();
+        let proj_dir = cwd.join("test_data").join("hover");
+        let save_dir = cwd
+            .join("target")
+            .join("tests")
+            .join("hover")
+            .join("save_data");
+        let load_dir = proj_dir.join("save_data");
+
+        let harness = TooltipTestHarness::new(proj_dir, &out);
+
+        out.reset();
+
+        let failures = harness.run_tests(&tests, load_dir, save_dir)?;
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            eprintln!("{}\n\n", out.reset().join("\n"));
+            eprintln!("{:#?}\n\n", failures);
+            Err(format!("{} of {} tooltip tests failed", failures.len(), tests.len()).into())
+        }
+    }
+
+    /// Note: This test is ignored as it doesn't work in the rust-lang/rust repo.
+    /// It is enabled on CI.
+    /// Run with `cargo test test_tooltip_std -- --ignored`
+    #[test]
+    #[ignore]
+    fn test_tooltip_std() -> Result<(), Box<dyn std::error::Error>> {
+        use self::test::{LineOutput, Test, TooltipTestHarness};
+        use std::env;
+
+        let tests = vec![
             Test::new("test_tooltip_std.rs", 18, 15),
             Test::new("test_tooltip_std.rs", 18, 27),
             Test::new("test_tooltip_std.rs", 19, 7),

--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -2095,8 +2095,6 @@ pub mod test {
             Test::new("test_tooltip_mod_use_external.rs", 11, 7),
             Test::new("test_tooltip_mod_use_external.rs", 12, 7),
             Test::new("test_tooltip_mod_use_external.rs", 12, 12),
-            Test::new("test_tooltip_mod_use_external.rs", 14, 12),
-            Test::new("test_tooltip_mod_use_external.rs", 15, 12),
         ];
 
         let cwd = env::current_dir()?;
@@ -2135,6 +2133,10 @@ pub mod test {
         use std::env;
 
         let tests = vec![
+            // these test std stuff
+            Test::new("test_tooltip_mod_use_external.rs", 14, 12),
+            Test::new("test_tooltip_mod_use_external.rs", 15, 12),
+
             Test::new("test_tooltip_std.rs", 18, 15),
             Test::new("test_tooltip_std.rs", 18, 27),
             Test::new("test_tooltip_std.rs", 19, 7),

--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -1289,6 +1289,10 @@ pub mod test {
 
     impl Drop for TooltipTestHarness {
         fn drop(&mut self) {
+            if let Ok(mut jobs) = self.ctx.jobs.lock() {
+                jobs.wait_for_all();
+            }
+
             if fs::metadata(&self.working_dir).is_ok() {
                 fs::remove_dir_all(&self.working_dir).expect("failed to tidy up");
             }

--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -782,17 +782,13 @@ fn format_object(rustfmt: Rustfmt, fmt_config: &FmtConfig, the_type: String) -> 
         format!("{}{{}}", trimmed)
     };
 
-    let formatted = match std::panic::catch_unwind(|| rustfmt.format(object.clone(), config)) {
-        Ok(Ok(lines)) => match lines.rfind('{') {
+    let formatted = match rustfmt.format(object.clone(), config) {
+        Ok(lines) => match lines.rfind('{') {
             Some(pos) => lines[0..pos].into(),
             None => lines,
         },
-        Ok(Err(e)) => {
+        Err(e) => {
             error!("format_object: error: {:?}, input: {:?}", e, object);
-            trimmed.to_string()
-        }
-        Err(_) => {
-            error!("format_object: rustfmt panicked on input: {:?}", object);
             trimmed.to_string()
         }
     };


### PR DESCRIPTION
After the discussion in #1151 this change:
* Splits test_tooltip into `test_tooltip` & `test_tooltip_std`. Only the latter will be ignored to avoid running upstream.
* Remove the `--cfg=enabled_tooltip_tests` stuff, the ignored test can be run with `cargo test -- --ignored`.
* Add string diff coloured output to tooltip tests.

<details><summary>Old/resolved</summary>
<p>

## Windows Tests
I also tried to get to the bottom of the windows test failures. I managed to reproduce it on my local machine and traced the error to a **panic without a backtrace** from a rustfmt call: https://github.com/rust-lang/rls/blob/bfa1371f5cceacebe307d9ee70760296eb0ec489/src/actions/hover.rs#L785
```
error: unexpected close delimiter: `}`
 --> <stdin>:5:1
  |
5 | }
  | ^ unexpected close delimiter
```

This was quite painful to find but can be handled with `std::panic::catch_unwind`. I've added logging init to the tooltip tests. Hopefully we can get to the bottom of the still failing windows tests now the panic will not kill the test run.


</p>
</details>
