### PR TITLE
Properly infer full_docs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -206,6 +206,7 @@ impl Config {
         new.target_dir = self.target_dir.combine_with_default(&new.target_dir, None);
         new.build_lib = self.build_lib.combine_with_default(&new.build_lib, false);
         new.build_bin = self.build_bin.combine_with_default(&new.build_bin, None);
+        new.full_docs = self.full_docs.combine_with_default(&new.full_docs, false);
 
         *self = new;
     }


### PR DESCRIPTION
3efe567b9ede ("Enhanced hover tooltips") added the `full_docs` configuration option as an `Inferrable`. However, it failed to actually merge the option during a config update, causing a panic if the client specified `full_docs` to be `null`. Example panic:

    thread '<unnamed>' panicked at 'internal error: entered unreachable code', src/config.rs:111:33

Fix this to prevent the crash.