### PR TITLE
WIP: Split RLS into bin/lib

### DIFF
--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -540,18 +540,18 @@ fn create_tooltip(
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// # use std::path::Path;
 ///
-/// let base_path = Path::from(".rustup/toolchains/nightly-x86_64-pc-windows-msvc/lib/rustlib/src/rust/src/liballoc/string.rs");
+/// let base_path = Path::new(".rustup/toolchains/nightly-x86_64-pc-windows-msvc/lib/rustlib/src/rust/src/liballoc/string.rs");
 /// let tidy_path = skip_path_components(base_path.to_path_buf(), ".rustup", 8);
 /// assert_eq!("liballoc/string.rs", tidy_path);
 ///
-/// let base_path = Path::from(".cargo/registry/src/github.com-1ecc6299db9ec823/smallvec-0.6.2/lib.rs");
+/// let base_path = Path::new(".cargo/registry/src/github.com-1ecc6299db9ec823/smallvec-0.6.2/lib.rs");
 /// let tidy_path = skip_path_components(base_path.to_path_buf(), ".cargo", 4);
 /// assert_eq!("smallvec-0.6.2/lib.rs", tidy_path);
 ///
-/// let base_path = Path::from("some/unknown/path/lib.rs");
+/// let base_path = Path::new("some/unknown/path/lib.rs");
 /// let tidy_path = skip_path_components(base_path.to_path_buf(), ".rustup", 4);
 /// assert_eq!("some/unknown/path/lib.rs", tidy_path);
 /// ```
@@ -578,7 +578,7 @@ fn skip_path_components<P: AsRef<Path>>(
 ///
 /// # Example
 ///
-/// ```
+/// ```ignore
 /// # use std::path::PathBuf;
 ///
 /// let path = PathBuf::from("libstd/../liballoc/string.rs");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,52 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! The Rust Language Server.
+//!
+//! The RLS provides a server that runs in the background, providing IDEs,
+//! editors, and other tools with information about Rust programs. It supports
+//! functionality such as 'goto definition', symbol search, reformatting, and
+//! code completion, and enables renaming and refactorings.
+
+#![feature(rustc_private, integer_atomics, drain_filter)]
+#![feature(crate_visibility_modifier)] // needed for edition 2018
+#![allow(unknown_lints)]
+#![warn(clippy::all, rust_2018_idioms)]
+#![allow(
+    clippy::cyclomatic_complexity,
+    clippy::needless_pass_by_value,
+    clippy::too_many_arguments
+)]
+
+use log::warn;
+use rustc_tools_util::*;
+
+pub use rls_analysis::{AnalysisHost, Target};
+pub use rls_vfs::Vfs;
+
+pub mod actions;
+pub mod build;
+pub mod cmd;
+pub mod concurrency;
+pub mod config;
+pub mod lsp_data;
+pub mod project_model;
+pub mod server;
+
+#[cfg(test)]
+mod test;
+
+type Span = rls_span::Span<rls_span::ZeroIndexed>;
+
+pub const RUSTC_SHIM_ENV_VAR_NAME: &str = "RLS_RUSTC_SHIM";
+
+pub fn version() -> String {
+    rustc_tools_util::get_version_info!().to_string()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,33 +37,16 @@
 )]
 extern "C" {}
 
+use rls;
+
 use log::warn;
 use env_logger;
-use rustc_tools_util::*;
+use rls_rustc as rustc_shim;
 
 use std::env;
 use std::sync::Arc;
 
-use rls_analysis::{AnalysisHost, Target};
-use rls_rustc as rustc_shim;
-use rls_vfs::Vfs;
-
-pub mod actions;
-pub mod build;
-pub mod cmd;
-pub mod concurrency;
-pub mod config;
-pub mod lsp_data;
-pub mod project_model;
-pub mod server;
-
-#[cfg(test)]
-mod test;
-
-const RUSTC_SHIM_ENV_VAR_NAME: &str = "RLS_RUSTC_SHIM";
 const RUSTC_WRAPPER_ENV_VAR: &str = "RUSTC_WRAPPER";
-
-type Span = rls_span::Span<rls_span::ZeroIndexed>;
 
 /// The main entry point to the RLS. Parses CLI arguments and then runs the
 /// server.
@@ -88,7 +71,7 @@ fn main_inner() -> i32 {
         env::remove_var(RUSTC_WRAPPER_ENV_VAR);
     }
 
-    if env::var(RUSTC_SHIM_ENV_VAR_NAME)
+    if env::var(rls::RUSTC_SHIM_ENV_VAR_NAME)
         .map(|v| v != "0")
         .unwrap_or(false)
     {
@@ -99,7 +82,7 @@ fn main_inner() -> i32 {
     if let Some(first_arg) = ::std::env::args().nth(1) {
         return match first_arg.as_str() {
             "--version" | "-V" => {
-                println!("{}", version().replace("rls", "rls-preview"));
+                println!("{}", rls::version().replace("rls", "rls-preview"));
                 0
             }
             "--help" | "-h" => {
@@ -107,7 +90,7 @@ fn main_inner() -> i32 {
                 0
             }
             "--cli" => {
-                cmd::run();
+                rls::cmd::run();
                 0
             }
             unknown => {
@@ -121,15 +104,10 @@ fn main_inner() -> i32 {
         };
     }
 
-    let analysis = Arc::new(AnalysisHost::new(Target::Debug));
-    let vfs = Arc::new(Vfs::new());
+    let analysis = Arc::new(rls::AnalysisHost::new(rls::Target::Debug));
+    let vfs = Arc::new(rls::Vfs::new());
 
-    server::run_server(analysis, vfs)
-}
-
-fn version() -> String {
-    let version = rustc_tools_util::get_version_info!();
-    version.to_string()
+    rls::server::run_server(analysis, vfs)
 }
 
 fn help() -> &'static str {


### PR DESCRIPTION
Next part of testing overhaul started at #1190. This should expose some bits that we couldn't query before using LSP messages alone (config inference, VFS content etc.).