### PR TITLE
Separate tooltip tests that require Racer fallback

### DIFF
--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -2067,7 +2067,11 @@ pub mod test {
     }
 
     // Common logic used in `test_tooltip_*` tests below
-    fn run_tooltip_tests(tests: &[Test], proj_dir: PathBuf, racer_completion: Racer) -> Result<(), Box<dyn std::error::Error>> {
+    fn run_tooltip_tests(
+        tests: &[Test],
+        proj_dir: PathBuf,
+        racer_completion: Racer,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let out = LineOutput::default();
 
         let save_dir_guard = tempfile::tempdir().unwrap();
@@ -2084,7 +2088,10 @@ pub mod test {
             Ok(())
         } else {
             eprintln!("{}\n\n", out.reset().join("\n"));
-            eprintln!("Failures (\x1b[91mexpected\x1b[92mactual\x1b[0m): {:#?}\n\n", failures);
+            eprintln!(
+                "Failures (\x1b[91mexpected\x1b[92mactual\x1b[0m): {:#?}\n\n",
+                failures
+            );
             Err(format!("{} of {} tooltip tests failed", failures.len(), tests.len()).into())
         }
     }

--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -2052,15 +2052,29 @@ pub mod test {
         assert_eq!(expected, actual);
     }
 
+    enum Racer {
+        Yes,
+        No,
+    }
+
+    impl Into<bool> for Racer {
+        fn into(self) -> bool {
+            match self {
+                Racer::Yes => true,
+                Racer::No => false,
+            }
+        }
+    }
+
     // Common logic used in `test_tooltip_*` tests below
-    fn run_tooltip_tests(tests: &[Test], proj_dir: PathBuf, racer_completion: bool) -> Result<(), Box<dyn std::error::Error>> {
+    fn run_tooltip_tests(tests: &[Test], proj_dir: PathBuf, racer_completion: Racer) -> Result<(), Box<dyn std::error::Error>> {
         let out = LineOutput::default();
 
         let save_dir_guard = tempfile::tempdir().unwrap();
         let save_dir = save_dir_guard.path().to_owned();
         let load_dir = proj_dir.join("save_data");
 
-        let harness = TooltipTestHarness::new(proj_dir, &out, racer_completion);
+        let harness = TooltipTestHarness::new(proj_dir, &out, racer_completion.into());
 
         out.reset();
 
@@ -2127,7 +2141,7 @@ pub mod test {
             Test::new("test_tooltip_mod_use.rs", 13, 28),
         ];
 
-        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), false)
+        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), Racer::No)
     }
 
     #[test]
@@ -2142,7 +2156,7 @@ pub mod test {
             Test::new("test_tooltip_mod_use_external.rs", 12, 12),
         ];
 
-        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), true)
+        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), Racer::Yes)
     }
 
     /// Note: This test is ignored as it doesn't work in the rust-lang/rust repo.
@@ -2169,7 +2183,7 @@ pub mod test {
             Test::new("test_tooltip_std.rs", 25, 25),
         ];
 
-        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), false)
+        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), Racer::No)
     }
 
     /// Note: This test is ignored as it doesn't work in the rust-lang/rust repo.
@@ -2186,6 +2200,6 @@ pub mod test {
             Test::new("test_tooltip_mod_use_external.rs", 15, 12),
         ];
 
-        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), true)
+        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), Racer::Yes)
     }
 }

--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -2052,10 +2052,32 @@ pub mod test {
         assert_eq!(expected, actual);
     }
 
+    // Common logic used in `test_tooltip_*` tests below
+    fn run_tooltip_tests(tests: &[Test], proj_dir: PathBuf, racer_completion: bool) -> Result<(), Box<dyn std::error::Error>> {
+        let out = LineOutput::default();
+
+        let save_dir_guard = tempfile::tempdir().unwrap();
+        let save_dir = save_dir_guard.path().to_owned();
+        let load_dir = proj_dir.join("save_data");
+
+        let harness = TooltipTestHarness::new(proj_dir, &out, racer_completion);
+
+        out.reset();
+
+        let failures = harness.run_tests(tests, load_dir, save_dir)?;
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            eprintln!("{}\n\n", out.reset().join("\n"));
+            eprintln!("Failures (\x1b[91mexpected\x1b[92mactual\x1b[0m): {:#?}\n\n", failures);
+            Err(format!("{} of {} tooltip tests failed", failures.len(), tests.len()).into())
+        }
+    }
+
     #[test]
     fn test_tooltip() -> Result<(), Box<dyn std::error::Error>> {
         let _ = env_logger::try_init();
-        use self::test::{LineOutput, Test, TooltipTestHarness};
 
         let tests = vec![
             Test::new("test_tooltip_01.rs", 13, 11),
@@ -2105,32 +2127,12 @@ pub mod test {
             Test::new("test_tooltip_mod_use.rs", 13, 28),
         ];
 
-        let out = LineOutput::default();
-        let proj_dir = FIXTURES_DIR.join("hover");
-
-        let save_dir_guard = tempfile::tempdir().unwrap();
-        let save_dir = save_dir_guard.path().to_owned();
-        let load_dir = proj_dir.join("save_data");
-
-        let harness = TooltipTestHarness::new(proj_dir, &out, false);
-
-        out.reset();
-
-        let failures = harness.run_tests(&tests, load_dir, save_dir)?;
-
-        if failures.is_empty() {
-            Ok(())
-        } else {
-            eprintln!("{}\n\n", out.reset().join("\n"));
-            eprintln!("Failures (\x1b[91mexpected\x1b[92mactual\x1b[0m): {:#?}\n\n", failures);
-            Err(format!("{} of {} tooltip tests failed", failures.len(), tests.len()).into())
-        }
+        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), false)
     }
 
     #[test]
     fn test_tooltip_racer() -> Result<(), Box<dyn std::error::Error>> {
         let _ = env_logger::try_init();
-        use self::test::{LineOutput, Test, TooltipTestHarness};
 
         let tests = vec![
             Test::new("test_tooltip_01.rs", 80, 11),
@@ -2140,26 +2142,7 @@ pub mod test {
             Test::new("test_tooltip_mod_use_external.rs", 12, 12),
         ];
 
-        let out = LineOutput::default();
-        let proj_dir = FIXTURES_DIR.join("hover");
-
-        let save_dir_guard = tempfile::tempdir().unwrap();
-        let save_dir = save_dir_guard.path().to_owned();
-        let load_dir = proj_dir.join("save_data");
-
-        let harness = TooltipTestHarness::new(proj_dir, &out, true);
-
-        out.reset();
-
-        let failures = harness.run_tests(&tests, load_dir, save_dir)?;
-
-        if failures.is_empty() {
-            Ok(())
-        } else {
-            eprintln!("{}\n\n", out.reset().join("\n"));
-            eprintln!("Failures (\x1b[91mexpected\x1b[92mactual\x1b[0m): {:#?}\n\n", failures);
-            Err(format!("{} of {} tooltip tests failed", failures.len(), tests.len()).into())
-        }
+        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), true)
     }
 
     /// Note: This test is ignored as it doesn't work in the rust-lang/rust repo.
@@ -2169,7 +2152,6 @@ pub mod test {
     #[ignore]
     fn test_tooltip_std() -> Result<(), Box<dyn std::error::Error>> {
         let _ = env_logger::try_init();
-        use self::test::{LineOutput, Test, TooltipTestHarness};
 
         let tests = vec![
             Test::new("test_tooltip_std.rs", 18, 15),
@@ -2187,26 +2169,7 @@ pub mod test {
             Test::new("test_tooltip_std.rs", 25, 25),
         ];
 
-        let out = LineOutput::default();
-        let proj_dir = FIXTURES_DIR.join("hover");
-
-        let save_dir_guard = tempfile::tempdir().unwrap();
-        let save_dir = save_dir_guard.path().to_owned();
-        let load_dir = proj_dir.join("save_data");
-
-        let harness = TooltipTestHarness::new(proj_dir, &out, false);
-
-        out.reset();
-
-        let failures = harness.run_tests(&tests, load_dir, save_dir)?;
-
-        if failures.is_empty() {
-            Ok(())
-        } else {
-            eprintln!("{}\n\n", out.reset().join("\n"));
-            eprintln!("Failures (\x1b[91mexpected\x1b[92mactual\x1b[0m): {:#?}\n\n", failures);
-            Err(format!("{} of {} tooltip tests failed", failures.len(), tests.len()).into())
-        }
+        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), false)
     }
 
     /// Note: This test is ignored as it doesn't work in the rust-lang/rust repo.
@@ -2216,7 +2179,6 @@ pub mod test {
     #[ignore]
     fn test_tooltip_std_racer() -> Result<(), Box<dyn std::error::Error>> {
         let _ = env_logger::try_init();
-        use self::test::{LineOutput, Test, TooltipTestHarness};
 
         let tests = vec![
             // these test std stuff
@@ -2224,25 +2186,6 @@ pub mod test {
             Test::new("test_tooltip_mod_use_external.rs", 15, 12),
         ];
 
-        let out = LineOutput::default();
-        let proj_dir = FIXTURES_DIR.join("hover");
-
-        let save_dir_guard = tempfile::tempdir().unwrap();
-        let save_dir = save_dir_guard.path().to_owned();
-        let load_dir = proj_dir.join("save_data");
-
-        let harness = TooltipTestHarness::new(proj_dir, &out, true);
-
-        out.reset();
-
-        let failures = harness.run_tests(&tests, load_dir, save_dir)?;
-
-        if failures.is_empty() {
-            Ok(())
-        } else {
-            eprintln!("{}\n\n", out.reset().join("\n"));
-            eprintln!("Failures (\x1b[91mexpected\x1b[92mactual\x1b[0m): {:#?}\n\n", failures);
-            Err(format!("{} of {} tooltip tests failed", failures.len(), tests.len()).into())
-        }
+        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), true)
     }
 }

--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -1199,6 +1199,10 @@ pub mod test {
             let temp_dir = tempfile::tempdir().unwrap().into_path();
             config.target_dir = config::Inferrable::Specified(Some(temp_dir.clone()));
             config.racer_completion = racer_fallback_completion;
+            // FIXME(#1195): This led to spurious failures on macOS; possibly
+            // because regular build and #[cfg(test)] did race or rls-analysis
+            // didn't lower them properly?
+            config.all_targets = false;
 
             let config = Arc::new(Mutex::new(config));
             let analysis = Arc::new(analysis::AnalysisHost::new(analysis::Target::Debug));

--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -2052,16 +2052,16 @@ pub mod test {
         assert_eq!(expected, actual);
     }
 
-    enum Racer {
+    enum RacerFallback {
         Yes,
         No,
     }
 
-    impl Into<bool> for Racer {
-        fn into(self) -> bool {
-            match self {
-                Racer::Yes => true,
-                Racer::No => false,
+    impl From<RacerFallback> for bool {
+        fn from(arg: RacerFallback) -> bool {
+            match arg {
+                RacerFallback::Yes => true,
+                RacerFallback::No => false,
             }
         }
     }
@@ -2070,7 +2070,7 @@ pub mod test {
     fn run_tooltip_tests(
         tests: &[Test],
         proj_dir: PathBuf,
-        racer_completion: Racer,
+        racer_completion: RacerFallback,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let out = LineOutput::default();
 
@@ -2148,7 +2148,7 @@ pub mod test {
             Test::new("test_tooltip_mod_use.rs", 13, 28),
         ];
 
-        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), Racer::No)
+        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), RacerFallback::No)
     }
 
     #[test]
@@ -2163,7 +2163,7 @@ pub mod test {
             Test::new("test_tooltip_mod_use_external.rs", 12, 12),
         ];
 
-        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), Racer::Yes)
+        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), RacerFallback::Yes)
     }
 
     /// Note: This test is ignored as it doesn't work in the rust-lang/rust repo.
@@ -2190,7 +2190,7 @@ pub mod test {
             Test::new("test_tooltip_std.rs", 25, 25),
         ];
 
-        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), Racer::No)
+        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), RacerFallback::No)
     }
 
     /// Note: This test is ignored as it doesn't work in the rust-lang/rust repo.
@@ -2207,6 +2207,6 @@ pub mod test {
             Test::new("test_tooltip_mod_use_external.rs", 15, 12),
         ];
 
-        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), Racer::Yes)
+        run_tooltip_tests(&tests, FIXTURES_DIR.join("hover"), RacerFallback::Yes)
     }
 }


### PR DESCRIPTION
Fixes #1195.

While it should be really a 'good first issue', due to spurious macOS failures I'd say we need this sooner rather than later, especially since test_tooltip will land soon on Rust CI now (we should know better what failed and why).

@alexheretic does it look good?