### PR TITLE
Use `home_dir` from `home` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,6 +1143,7 @@ dependencies = [
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "home 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "languageserver-types 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ cargo_metadata = "0.6"
 clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "a3c77f6ad1c1c185e561e9cd7fdec7db569169d1", optional = true }
 env_logger = "0.5"
 failure = "0.1.1"
+home = "0.3"
 itertools = "0.7.3"
 jsonrpc-core = "8.0.1"
 languageserver-types = "0.51"

--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -15,6 +15,7 @@ use crate::config::FmtConfig;
 use crate::lsp_data::*;
 use crate::server::ResponseError;
 
+use home;
 use racer;
 use rls_analysis::{Def, DefKind};
 use rls_span::{Column, Row, Span, ZeroIndexed};
@@ -646,10 +647,7 @@ fn racer_match_to_def(ctx: &InitActionContext, m: &racer::Match) -> Option<Def> 
     let contextstr = if kind == DefKind::Mod {
         use std::env;
 
-        let home = env::var("HOME")
-            .or_else(|_| env::var("USERPROFILE"))
-            .map(PathBuf::from)
-            .unwrap_or_default();
+        let home = home::home_dir().unwrap_or_default();
         let rustup_home = env::var("RUSTUP_HOME")
             .map(PathBuf::from)
             .unwrap_or_else(|_| home.join(".rustup"));


### PR DESCRIPTION
The `$HOME` -> `$USERPROFILE` fallback logic does not work for Windows
when running builds under `sh`. We don't canonicalize the path here so
just rely on checking `$USERPROFILE` first and that it has
`C:\Windows\Style` path instead of `/unix/one` (shape is important when
stripping prefix).

Use `home ^0.3` since that's what Cargo uses [right now](https://github.com/rust-lang/cargo/blob/1dff476dcadbf5878d640a732037d931879ed209/Cargo.toml#L38).