### PR TITLE
Change all mentions of `rls-preview` to `rls`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/rust-lang/rls.svg?branch=master)](https://travis-ci.org/rust-lang/rls)
-[![Nightly status](https://img.shields.io/badge/dynamic/json.svg?label=rls-preview%20(Windows)&url=https%3A%2F%2Fraw.githubusercontent.com%2Frust-lang-nursery%2Frust-toolstate%2Fmaster%2F_data%2Flatest.json&query=%24%5B%3F(%40.tool%3D%3D%22rls%22)%5D.windows&colorB=lightgrey)](https://rust-lang-nursery.github.io/rust-toolstate/)
-[![Nightly status](https://img.shields.io/badge/dynamic/json.svg?label=rls-preview%20(Linux)&url=https%3A%2F%2Fraw.githubusercontent.com%2Frust-lang-nursery%2Frust-toolstate%2Fmaster%2F_data%2Flatest.json&query=%24%5B%3F(%40.tool%3D%3D%22rls%22)%5D.linux&colorB=lightgrey)](https://rust-lang-nursery.github.io/rust-toolstate/)
+[![Nightly status](https://img.shields.io/badge/dynamic/json.svg?label=rls%20(Windows)&url=https%3A%2F%2Fraw.githubusercontent.com%2Frust-lang-nursery%2Frust-toolstate%2Fmaster%2F_data%2Flatest.json&query=%24%5B%3F(%40.tool%3D%3D%22rls%22)%5D.windows&colorB=lightgrey)](https://rust-lang-nursery.github.io/rust-toolstate/)
+[![Nightly status](https://img.shields.io/badge/dynamic/json.svg?label=rls%20(Linux)&url=https%3A%2F%2Fraw.githubusercontent.com%2Frust-lang-nursery%2Frust-toolstate%2Fmaster%2F_data%2Flatest.json&query=%24%5B%3F(%40.tool%3D%3D%22rls%22)%5D.linux&colorB=lightgrey)](https://rust-lang-nursery.github.io/rust-toolstate/)
 
 
 
@@ -51,11 +51,11 @@ If you're going to use the VSCode extension, you can skip step 2.
 Once you have rustup installed, run the following commands:
 
 ```
-rustup component add rls-preview rust-analysis rust-src
+rustup component add rls rust-analysis rust-src
 ```
 
 #### Note (nightly only)
-Sometimes the `rls-preview` component is not included in a nightly build due to
+Sometimes the `rls` component is not included in a nightly build due to
 certain issues. To see if the component is included in a particular build and
 what to do if it's not, check [#641](https://github.com/rust-lang/rls/issues/641).
 

--- a/clients.md
+++ b/clients.md
@@ -55,8 +55,7 @@ Once you have this basic support in place, the hard work begins:
   - For the config options, see [config.rs](https://github.com/rust-lang/rls/blob/master/src/config.rs#L99-L117)
 * Check for and install the RLS
   - you should use Rustup
-  - you should check the RLS is installed, and if not, install it and the `rust-analysis` and `rust-src` components
-  - be aware that the RLS component is changing name - currently `rls`, will become `rls-preview`.
+  - you should check if the RLS (`rls`) is installed, and if not, install it and the `rust-analysis` and `rust-src` components
   - you should provide a way to update the RLS component
 * Client-side features
   - e.g., code snippets, build tasks, syntax highlighting

--- a/debugging.md
+++ b/debugging.md
@@ -22,7 +22,7 @@ issues.
 
 ### Missing RLS component
 
-You might see an error like `toolchain 'nightly-x86_64-unknown-linux-gnu' does not contain component 'rls-preview' for target 'x86_64-unknown-linux-gnu'`.
+You might see an error like `toolchain 'nightly-x86_64-unknown-linux-gnu' does not contain component 'rls' for target 'x86_64-unknown-linux-gnu'`.
 
 This is due to a nightly release missing the RLS component. That
 happens occasionally when the RLS cannot be built with the current compiler. To

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ fn main_inner() -> i32 {
     if let Some(first_arg) = ::std::env::args().nth(1) {
         return match first_arg.as_str() {
             "--version" | "-V" => {
-                println!("{}", version().replace("rls", "rls-preview"));
+                println!("{}", version());
                 0
             }
             "--help" | "-h" => {


### PR DESCRIPTION
Rust 1.31 (Rust 2018) dropped the `-preview` suffix.

r? @nrc