### PR TITLE
Delete bors.toml

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,0 @@
-status = [
-  "continuous-integration/travis-ci/push"
-]


### PR DESCRIPTION
We're about to be using default rust-lang bors: https://github.com/rust-lang/rust-central-station/pull/134.