### PR TITLE
Don't pass now removed MakeGlob parameter to rustc

### DIFF
--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -346,7 +346,6 @@ impl<'a> CompilerCalls<'a> for RlsRustcCalls {
             );
         });
         result.after_analysis.run_callback_on_error = true;
-        result.make_glob_map = rustc_resolve::MakeGlobMap::Yes;
 
         result
     }


### PR DESCRIPTION
Needed for https://github.com/rust-lang/rust/pull/57392 (Rust RLS submodule already points to this commit).