### PR TITLE
Add missing clippy_lint register calls

### DIFF
--- a/src/build/rustc.rs
+++ b/src/build/rustc.rs
@@ -220,6 +220,8 @@ fn clippy_after_parse_callback(state: &mut rustc_driver::driver::CompileState<'_
     for (name, (to, deprecated_name)) in lint_groups {
         ls.register_group(Some(sess), true, name, deprecated_name, to);
     }
+    clippy_lints::register_pre_expansion_lints(sess, &mut ls, &conf);
+    clippy_lints::register_renamed(&mut ls);
 
     sess.plugin_llvm_passes.borrow_mut().extend(llvm_passes);
     sess.plugin_attributes.borrow_mut().extend(attributes);


### PR DESCRIPTION

I found some extra calls to make: https://github.com/rust-lang/rust-clippy/blob/da7aebc342b7dae444912b98dedbab22bf2a224c/src/driver.rs#L135-L136

Fixes #1241