### PR TITLE
Bump RLS to 1.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "rls"
-version = "1.33.0"
+version = "1.34.0"
 dependencies = [
  "cargo 0.35.0 (git+https://github.com/rust-lang/cargo?rev=245818076052dd7178f5bb7585f5aec5b6c1e03e)",
  "cargo_metadata 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rls"
-version = "1.33.0"
+version = "1.34.0"
 edition = "2018"
 authors = ["Nick Cameron <ncameron@mozilla.com>", "The RLS developers"]
 description = "Rust Language Server - provides information about Rust programs to IDEs and other tools"


### PR DESCRIPTION
We'd like to keep track with the current Rust version.