### PR TITLE
Implement range for hover response

### DIFF
--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -18,12 +18,19 @@ use crate::server::ResponseError;
 use home;
 use racer;
 use rls_analysis::{Def, DefKind};
-use rls_span::{Column, Row, Span, ZeroIndexed};
+use rls_span::{Column, Range, Row, Span, ZeroIndexed};
 use rls_vfs::{self as vfs, Vfs};
 use rustfmt_nightly::NewlineStyle;
+use serde_derive::{Deserialize, Serialize};
 
 use log::*;
 use std::path::{Path, PathBuf};
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct Tooltip {
+    pub contents: Vec<MarkedString>,
+    pub range: Range<ZeroIndexed>,
+}
 
 /// Cleanup documentation code blocks. The `docs` are expected to have
 /// the preceding `///` or `//!` prefixes already trimmed away. Rust code
@@ -878,7 +885,7 @@ fn format_method(rustfmt: Rustfmt, fmt_config: &FmtConfig, the_type: String) -> 
 pub fn tooltip(
     ctx: &InitActionContext,
     params: &TextDocumentPositionParams,
-) -> Result<Vec<MarkedString>, ResponseError> {
+    ) -> Result<Tooltip, ResponseError> {
     let analysis = &ctx.analysis;
 
     let hover_file_path = parse_file_path!(&params.text_document.uri, "hover")?;
@@ -965,7 +972,7 @@ pub fn tooltip(
         Vec::default()
     };
     debug!("tooltip: contents.len: {}", contents.len());
-    Ok(contents)
+    Ok(Tooltip{ contents, range: hover_span.range })
 }
 
 #[cfg(test)]

--- a/src/actions/hover.rs
+++ b/src/actions/hover.rs
@@ -885,7 +885,7 @@ fn format_method(rustfmt: Rustfmt, fmt_config: &FmtConfig, the_type: String) -> 
 pub fn tooltip(
     ctx: &InitActionContext,
     params: &TextDocumentPositionParams,
-    ) -> Result<Tooltip, ResponseError> {
+) -> Result<Tooltip, ResponseError> {
     let analysis = &ctx.analysis;
 
     let hover_file_path = parse_file_path!(&params.text_document.uri, "hover")?;

--- a/src/actions/requests.rs
+++ b/src/actions/requests.rs
@@ -146,8 +146,8 @@ impl RequestAction for Hover {
         let tooltip = hover::tooltip(&ctx, &params)?;
 
         Ok(lsp_data::Hover {
-            contents: HoverContents::Array(tooltip),
-            range: None, // TODO: maybe add?
+            contents: HoverContents::Array(tooltip.contents),
+            range: Some(ls_util::rls_to_range(tooltip.range)),
         })
     }
 }

--- a/tests/tooltip.rs
+++ b/tests/tooltip.rs
@@ -1,4 +1,4 @@
-use rls::actions::hover::tooltip;
+use rls::actions::hover::{tooltip, Tooltip};
 use rls::actions::{ActionContext, InitActionContext};
 use rls::config;
 use rls::lsp_data::{ClientCapabilities, InitializationOptions};
@@ -49,7 +49,7 @@ impl Test {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 struct TestResult {
     test: Test,
-    data: Result<Vec<MarkedString>, String>,
+    data: Result<Tooltip, String>,
 }
 
 impl TestResult {
@@ -69,9 +69,9 @@ impl TestResult {
     /// `MarkedString::String` in `other` need only start with self's.
     fn has_same_data_start(&self, other: &Self) -> bool {
         match (&self.data, &other.data) {
-            (Ok(data), Ok(them)) if data.len() == them.len() => data
+            (Ok(data), Ok(them)) if data.contents.len() == them.contents.len() => data.contents
                 .iter()
-                .zip(them.iter())
+                .zip(them.contents.iter())
                 .map(|(us, them)| match (us, them) {
                     (MarkedString::String(us), MarkedString::String(them)) => them.starts_with(us),
                     _ => us == them,
@@ -123,10 +123,10 @@ pub struct TestFailure {
     /// The expected outcome. The outer `Result` relates to errors while
     /// loading saved data. The inner `Result` is the saved output from
     /// `hover::tooltip`.
-    pub expect_data: Result<Result<Vec<MarkedString>, String>, String>,
+    pub expect_data: Result<Result<Tooltip, String>, String>,
     /// The current output from `hover::tooltip`. The inner `Result`
     /// is the output from `hover::tooltip`.
-    pub actual_data: Result<Result<Vec<MarkedString>, String>, ()>,
+    pub actual_data: Result<Result<Tooltip, String>, ()>,
 }
 
 impl fmt::Debug for TestFailure {

--- a/tests/tooltip.rs
+++ b/tests/tooltip.rs
@@ -1,4 +1,4 @@
-use rls::actions::hover::{tooltip, Tooltip};
+use rls::actions::hover::tooltip;
 use rls::actions::{ActionContext, InitActionContext};
 use rls::config;
 use rls::lsp_data::{ClientCapabilities, InitializationOptions};


### PR DESCRIPTION
Implement optional `range` property for `textDocument/hover` response: https://microsoft.github.io/language-server-protocol/specification#textDocument_hover