### PR TITLE
Bumpup cargo from 2458180 to 4e74e2f

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,14 +108,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "cargo"
 version = "0.35.0"
-source = "git+https://github.com/rust-lang/cargo?rev=245818076052dd7178f5bb7585f5aec5b6c1e03e#245818076052dd7178f5bb7585f5aec5b6c1e03e"
+source = "git+https://github.com/rust-lang/cargo?rev=4e74e2fc0908524d17735c768067117d3e84ee9c#4e74e2fc0908524d17735c768067117d3e84ee9c"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crates-io 0.23.0 (git+https://github.com/rust-lang/cargo?rev=245818076052dd7178f5bb7585f5aec5b6c1e03e)",
+ "crates-io 0.23.0 (git+https://github.com/rust-lang/cargo?rev=4e74e2fc0908524d17735c768067117d3e84ee9c)",
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-hash 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -271,7 +271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "crates-io"
 version = "0.23.0"
-source = "git+https://github.com/rust-lang/cargo?rev=245818076052dd7178f5bb7585f5aec5b6c1e03e#245818076052dd7178f5bb7585f5aec5b6c1e03e"
+source = "git+https://github.com/rust-lang/cargo?rev=4e74e2fc0908524d17735c768067117d3e84ee9c#4e74e2fc0908524d17735c768067117d3e84ee9c"
 dependencies = [
  "curl 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1386,7 +1386,7 @@ dependencies = [
 name = "rls"
 version = "1.34.0"
 dependencies = [
- "cargo 0.35.0 (git+https://github.com/rust-lang/cargo?rev=245818076052dd7178f5bb7585f5aec5b6c1e03e)",
+ "cargo 0.35.0 (git+https://github.com/rust-lang/cargo?rev=4e74e2fc0908524d17735c768067117d3e84ee9c)",
  "cargo_metadata 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy_lints 0.0.212 (git+https://github.com/rust-lang/rust-clippy?rev=3bda548f81bc268a2e9813ce9168d2e40e8a11bd)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2280,7 +2280,7 @@ dependencies = [
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"
-"checksum cargo 0.35.0 (git+https://github.com/rust-lang/cargo?rev=245818076052dd7178f5bb7585f5aec5b6c1e03e)" = "<none>"
+"checksum cargo 0.35.0 (git+https://github.com/rust-lang/cargo?rev=4e74e2fc0908524d17735c768067117d3e84ee9c)" = "<none>"
 "checksum cargo_metadata 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1b4d380e1bab994591a24c2bdd1b054f64b60bef483a8c598c7c345bc3bbe"
 "checksum cargo_metadata 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "585784cac9b05c93a53b17a0b24a5cdd1dfdda5256f030e089b549d2390cc720"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
@@ -2292,7 +2292,7 @@ dependencies = [
 "checksum commoncrypto-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
 "checksum core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e2640d6d0bf22e82bed1b73c6aef8d5dd31e5abe6666c57e6d45e2649f4f887"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
-"checksum crates-io 0.23.0 (git+https://github.com/rust-lang/cargo?rev=245818076052dd7178f5bb7585f5aec5b6c1e03e)" = "<none>"
+"checksum crates-io 0.23.0 (git+https://github.com/rust-lang/cargo?rev=4e74e2fc0908524d17735c768067117d3e84ee9c)" = "<none>"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crc32fast 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e91d5240c6975ef33aeb5f148f35275c25eda8e8a5f95abe421978b05b8bf192"
 "checksum crossbeam 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad4c7ea749d9fb09e23c5cb17e3b70650860553a0e2744e38446b1803bf7db94"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ name = "rls"
 test = false
 
 [dependencies]
-cargo = { git = "https://github.com/rust-lang/cargo", rev = "245818076052dd7178f5bb7585f5aec5b6c1e03e" }
+cargo = { git = "https://github.com/rust-lang/cargo", rev = "4e74e2fc0908524d17735c768067117d3e84ee9c" }
 cargo_metadata = "0.7"
 clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "3bda548f81bc268a2e9813ce9168d2e40e8a11bd", optional = true }
 env_logger = "0.6"


### PR DESCRIPTION
related with https://github.com/rust-lang/rust/pull/58131

diff: https://github.com/rust-lang/cargo/compare/2458180...4e74e2f