### PR TITLE
Prefer {AtomicUsize,Once}::new

### DIFF
--- a/tests/support/paths.rs
+++ b/tests/support/paths.rs
@@ -5,16 +5,16 @@ use std::env;
 use std::fs;
 use std::io::{self, ErrorKind};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
-use std::sync::{Once, ONCE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Once;
 
 static RLS_INTEGRATION_TEST_DIR: &'static str = "rlsit";
-static NEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
 thread_local!(static TASK_ID: usize = NEXT_ID.fetch_add(1, Ordering::SeqCst));
 
 fn init() {
-    static GLOBAL_INIT: Once = ONCE_INIT;
+    static GLOBAL_INIT: Once = Once::new();
     thread_local!(static LOCAL_INIT: Cell<bool> = Cell::new(false));
     GLOBAL_INIT.call_once(|| {
         global_root().mkdir_p();


### PR DESCRIPTION
Since the `ATOMIC_USIZE_INIT` is deprecated (figured `ONCE_INIT` is likely to follow?).