### PR TITLE
implement kebab case config support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,6 +661,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1402,7 @@ dependencies = [
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "home 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2334,6 +2343,7 @@ dependencies = [
 "checksum git2-curl 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d58551e903ed7e2d6fe3a2f3c7efa3a784ec29b19d0fbb035aaf0497c183fbdd"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum home 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "29302b90cfa76231a757a887d1e3153331a63c7f80b6c75f86366334cbe70708"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ regex = "1"
 ordslice = "0.3"
 crossbeam-channel = "0.3"
 toml = "0.4"
-heck = "0.3.1"
+heck = "0.3"
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ regex = "1"
 ordslice = "0.3"
 crossbeam-channel = "0.3"
 toml = "0.4"
+heck = "0.3.1"
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -306,7 +306,7 @@ impl InitActionContext {
         let needs_inference = {
             let mut config = self.config.lock().unwrap();
 
-            if let Some(init_config) = init_options.settings.map(|s| s.rust) {
+            if let Some(init_config) = init_options.settings.map(|s| s.rust.0) {
                 config.update(init_config);
             }
             config.needs_inference()

--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -1,4 +1,4 @@
-// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -150,11 +150,12 @@ impl BlockingNotificationAction for Cancel {
 
 impl BlockingNotificationAction for DidChangeConfiguration {
     fn handle<O: Output>(
-        params: DidChangeConfigurationParams,
+        mut params: DidChangeConfigurationParams,
         ctx: &mut InitActionContext,
         out: O,
     ) -> Result<(), ()> {
         trace!("config change: {:?}", params.settings);
+	params.settings = crate::lsp_data::transform_json_key_one_level(params.settings);
         let settings = ChangeConfigSettings::deserialize(&params.settings);
 
         let new_config = match settings {

--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -160,8 +160,8 @@ impl BlockingNotificationAction for DidChangeConfiguration {
 
         let new_config = match settings {
             Ok(mut value) => {
-                value.rust.normalise();
-                value.rust
+                value.rust.0.normalise();
+                value.rust.0
             }
             Err(err) => {
                 warn!(

--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -155,7 +155,7 @@ impl BlockingNotificationAction for DidChangeConfiguration {
         out: O,
     ) -> Result<(), ()> {
         trace!("config change: {:?}", params.settings);
-	params.settings = crate::lsp_data::transform_json_key_one_level(params.settings);
+	params.settings = crate::lsp_data::json_key_to_snake_case(params.settings);
         let settings = ChangeConfigSettings::deserialize(&params.settings);
 
         let new_config = match settings {

--- a/src/actions/notifications.rs
+++ b/src/actions/notifications.rs
@@ -1,4 +1,4 @@
-
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -246,10 +246,31 @@ impl RangeExt for Range {
     }
 }
 
+pub struct Config(pub config::Config);
+
+impl<'de> serde::Deserialize<'de> for Config {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de> {
+            use serde::de::Error;
+            let val = transform_json_key_one_level(serde_json::Value::deserialize(deserializer)?);
+            match serde_json::from_value(val) {
+                Ok(config) => Ok(Config(config)),
+                _ => Err(D::Error::custom("unable to deserialize Config")),
+            }
+        }
+}
+
+impl fmt::Debug for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
+
 /// `DidChangeConfigurationParams.settings` payload reading the { rust: {...} } bit.
 #[derive(Debug, Deserialize)]
 pub struct ChangeConfigSettings {
-    pub rust: config::Config,
+    pub rust: Config,
 }
 
 /* -----------------  JSON-RPC protocol types ----------------- */

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -442,4 +442,3 @@ pub fn json_key_to_snake_case(mut val: serde_json::Value) -> serde_json::Value {
     val
 }
 
-

--- a/tests/tests_old.rs
+++ b/tests/tests_old.rs
@@ -1105,8 +1105,59 @@ fn test_omit_init_build() {
     );
 }
 
-#[test]
-fn test_init_with_configuration() {
+
+pub trait ConvertStringCase {
+    fn convert_string_case(s: &str) -> String;
+}
+
+struct IdentityConverter;
+impl ConvertStringCase for IdentityConverter {
+    fn convert_string_case<'a>(s:&'a str) -> String {
+      s.to_string()
+    }
+}
+
+struct CamelCaseConverter;
+impl ConvertStringCase for CamelCaseConverter {
+    fn convert_string_case<'a>(s:&'a str) -> String {
+      use heck::CamelCase;
+      s.to_camel_case().to_string()
+    }
+}
+
+struct KebabCaseConverter;
+impl ConvertStringCase for KebabCaseConverter {
+    fn convert_string_case<'a>(s:&'a str) -> String {
+      use heck::KebabCase;
+      s.to_kebab_case().to_string()
+    }
+}
+
+struct ShoutySnakeCaseConverter;
+impl ConvertStringCase for ShoutySnakeCaseConverter {
+    fn convert_string_case<'a>(s:&'a str) -> String {
+      use heck::ShoutySnakeCase;
+      s.to_shouty_snake_case().to_string()
+    }
+}
+
+struct SnakeCaseConverter;
+impl ConvertStringCase for SnakeCaseConverter {
+    fn convert_string_case<'a>(s:&'a str) -> String {
+      use heck::SnakeCase;
+      s.to_snake_case().to_string()
+    }
+}
+
+struct TitleCaseConverter;
+impl ConvertStringCase for TitleCaseConverter {
+    fn convert_string_case<'a>(s:&'a str) -> String {
+      use heck::TitleCase;
+      s.to_title_case().to_string()
+    }
+}
+
+fn test_init_impl<T:ConvertStringCase>() {
     use serde_json::json;
 
     let mut env = Environment::generate_from_fixture("common");
@@ -1116,8 +1167,8 @@ fn test_init_with_configuration() {
     let init_options = json!({
         "settings": {
             "rust": {
-                "features": ["some_feature"],
-                "all_targets": false
+                T::convert_string_case("features"): ["some_feature"],
+                T::convert_string_case("all_targets"): false
             }
         }
     });
@@ -1143,6 +1194,36 @@ fn test_init_with_configuration() {
 
     assert_eq!(&config.lock().unwrap().features, &["some_feature"]);
     assert_eq!(config.lock().unwrap().all_targets, false);
+}
+
+#[test]
+fn test_init_with_configuration() {
+    test_init_impl::<IdentityConverter>();
+}
+
+#[test]
+fn test_init_with_configuration_camel_case() {
+    test_init_impl::<CamelCaseConverter>();
+}
+
+#[test]
+fn test_init_with_configuration_kebab_case() {
+    test_init_impl::<KebabCaseConverter>();
+}
+
+#[test]
+fn test_init_with_configuration_shouty_snake_case() {
+    test_init_impl::<ShoutySnakeCaseConverter>();
+}
+
+#[test]
+fn test_init_with_configuration_snake_case() {
+    test_init_impl::<SnakeCaseConverter>();
+}
+
+#[test]
+fn test_init_with_configuration_title_case() {
+    test_init_impl::<TitleCaseConverter>();
 }
 
 #[test]

--- a/tests/tests_old.rs
+++ b/tests/tests_old.rs
@@ -1105,16 +1105,8 @@ fn test_omit_init_build() {
     );
 }
 
-
 pub trait ConvertStringCase {
     fn convert_string_case(s: &str) -> String;
-}
-
-struct IdentityConverter;
-impl ConvertStringCase for IdentityConverter {
-    fn convert_string_case<'a>(s:&'a str) -> String {
-      s.to_string()
-    }
 }
 
 struct CamelCaseConverter;
@@ -1122,6 +1114,22 @@ impl ConvertStringCase for CamelCaseConverter {
     fn convert_string_case<'a>(s:&'a str) -> String {
       use heck::CamelCase;
       s.to_camel_case().to_string()
+    }
+}
+
+struct KebabCaseConverter;
+impl ConvertStringCase for KebabCaseConverter {
+    fn convert_string_case<'a>(s:&'a str) -> String {
+      use heck::KebabCase;
+      s.to_kebab_case().to_string()
+    }
+}
+
+struct SnakeCaseConverter;
+impl ConvertStringCase for SnakeCaseConverter {
+    fn convert_string_case<'a>(s:&'a str) -> String {
+      use heck::SnakeCase;
+      s.to_snake_case().to_string()
     }
 }
 
@@ -1165,13 +1173,18 @@ fn test_init_impl<T:ConvertStringCase>() {
 }
 
 #[test]
-fn test_init_with_configuration() {
-    test_init_impl::<IdentityConverter>();
+fn test_init_with_configuration_camel_case() {
+    test_init_impl::<CamelCaseConverter>();
 }
 
 #[test]
-fn test_init_with_configuration_camel_case() {
-    test_init_impl::<CamelCaseConverter>();
+fn test_init_with_configuration_kebab_case() {
+    test_init_impl::<KebabCaseConverter>();
+}
+
+#[test]
+fn test_init_with_configuration_snake_case() {
+    test_init_impl::<SnakeCaseConverter>();
 }
 
 #[test]

--- a/tests/tests_old.rs
+++ b/tests/tests_old.rs
@@ -1125,38 +1125,6 @@ impl ConvertStringCase for CamelCaseConverter {
     }
 }
 
-struct KebabCaseConverter;
-impl ConvertStringCase for KebabCaseConverter {
-    fn convert_string_case<'a>(s:&'a str) -> String {
-      use heck::KebabCase;
-      s.to_kebab_case().to_string()
-    }
-}
-
-struct ShoutySnakeCaseConverter;
-impl ConvertStringCase for ShoutySnakeCaseConverter {
-    fn convert_string_case<'a>(s:&'a str) -> String {
-      use heck::ShoutySnakeCase;
-      s.to_shouty_snake_case().to_string()
-    }
-}
-
-struct SnakeCaseConverter;
-impl ConvertStringCase for SnakeCaseConverter {
-    fn convert_string_case<'a>(s:&'a str) -> String {
-      use heck::SnakeCase;
-      s.to_snake_case().to_string()
-    }
-}
-
-struct TitleCaseConverter;
-impl ConvertStringCase for TitleCaseConverter {
-    fn convert_string_case<'a>(s:&'a str) -> String {
-      use heck::TitleCase;
-      s.to_title_case().to_string()
-    }
-}
-
 fn test_init_impl<T:ConvertStringCase>() {
     use serde_json::json;
 
@@ -1204,26 +1172,6 @@ fn test_init_with_configuration() {
 #[test]
 fn test_init_with_configuration_camel_case() {
     test_init_impl::<CamelCaseConverter>();
-}
-
-#[test]
-fn test_init_with_configuration_kebab_case() {
-    test_init_impl::<KebabCaseConverter>();
-}
-
-#[test]
-fn test_init_with_configuration_shouty_snake_case() {
-    test_init_impl::<ShoutySnakeCaseConverter>();
-}
-
-#[test]
-fn test_init_with_configuration_snake_case() {
-    test_init_impl::<SnakeCaseConverter>();
-}
-
-#[test]
-fn test_init_with_configuration_title_case() {
-    test_init_impl::<TitleCaseConverter>();
 }
 
 #[test]


### PR DESCRIPTION
This pr tries to implement half of what's said in #1153 (reporting unused configs can be implemented in a separate pr). It introduces a new dependency on [heck](https://crates.io/crates/heck) for case conversion, add a little bit tweak to [struct Config in lsp_data.rs](https://github.com/lijinpei/rls/commit/cbeb77b03759cefe9091e4587aabb249adaff6c9#diff-5c71a9e04104a098c5f6e6f6af6a2ff5R249) so that Config'keys can be deserialized ignoring case(It basically first deserializes to a serde_json::Value, convert the case, then deserializes to the real struct Config), and add a few test-cases.