### PR TITLE
Remove unnecessary #![feature]s

### DIFF
--- a/rls-analysis/src/analysis.rs
+++ b/rls-analysis/src/analysis.rs
@@ -19,7 +19,7 @@ use {Id, Span, SymbolQuery};
 /// such as definitions, their mapping between spans, hierarchy and so on,
 /// organized in a per-crate fashion.
 #[derive(Debug)]
-crate struct Analysis {
+pub(crate) struct Analysis {
     /// Contains lowered data with global inter-crate `Id`s per each crate.
     pub per_crate: HashMap<CrateId, PerCrateAnalysis>,
 
@@ -30,10 +30,10 @@ crate struct Analysis {
     //
     // In the future we should handle imports, in particular aliasing ones, more
     // explicitly and then this can be removed.
-    crate aliased_imports: HashSet<Id>,
+    pub(crate) aliased_imports: HashSet<Id>,
 
     // Maps a crate names to the crate ids for all crates with that name.
-    crate crate_names: HashMap<String, Vec<CrateId>>,
+    pub(crate) crate_names: HashMap<String, Vec<CrateId>>,
 
     pub doc_url_base: String,
     pub src_url_base: String,
@@ -156,7 +156,7 @@ impl PerCrateAnalysis {
 
     // Returns true if there is a def in this crate with the same crate-local id
     // and span as `def`.
-    crate fn has_congruent_def(&self, local_id: u32, span: &Span) -> bool {
+    pub(crate) fn has_congruent_def(&self, local_id: u32, span: &Span) -> bool {
         let id = Id::from_crate_and_local(self.global_crate_num, local_id);
         match self.defs.get(&id) {
             Some(existing) => span == &existing.span,

--- a/rls-analysis/src/lib.rs
+++ b/rls-analysis/src/lib.rs
@@ -6,9 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(type_ascription)]
-#![feature(crate_visibility_modifier)]
-
 #[macro_use]
 extern crate derive_new;
 #[macro_use]
@@ -400,7 +397,7 @@ impl<L: AnalysisLoader> AnalysisHost<L> {
                         .unwrap_or_else(Vec::new)
                         .into_iter()
                     })
-                    .collect(): Vec<Span>
+                    .collect::<Vec<Span>>()
             }))
         });
 

--- a/rls-rustc/.gitignore
+++ b/rls-rustc/.gitignore
@@ -1,2 +1,3 @@
 /target/
 **/*.rs.bk
+Cargo.lock

--- a/rls-rustc/Cargo.lock
+++ b/rls-rustc/Cargo.lock
@@ -1,4 +1,0 @@
-[[package]]
-name = "rls-rustc"
-version = "0.5.0"
-

--- a/rls-rustc/src/lib.rs
+++ b/rls-rustc/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(rustc_private)]
-#![feature(box_syntax)]
 
 extern crate env_logger;
 extern crate getopts;

--- a/rls-vfs/src/lib.rs
+++ b/rls-vfs/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(type_ascription)]
-
 extern crate rls_span as span;
 #[macro_use]
 extern crate log;

--- a/rls-vfs/src/test.rs
+++ b/rls-vfs/src/test.rs
@@ -216,7 +216,7 @@ fn test_user_data(with_len: bool) {
     assert_eq!(
         vfs.with_user_data(&Path::new("foo"), |u| {
             assert_eq!(*u.unwrap().1, 43);
-            Err(Error::BadLocation): Result<(), Error>
+            Result::Err::<(), Error>(Error::BadLocation)
         }),
         Err(Error::BadLocation)
     );
@@ -237,7 +237,9 @@ fn test_user_data(with_len: bool) {
     // Compute (clear) and read data.
     vfs.set_user_data(&Path::new("foo"), Some(42)).unwrap();
     assert_eq!(
-        vfs.with_user_data(&Path::new("foo"), |_| Err(Error::NoUserDataForFile): Result<(), Error>),
+        vfs.with_user_data(&Path::new("foo"), |_| Result::Err::<(), Error>(
+            Error::NoUserDataForFile
+        )),
         Err(Error::NoUserDataForFile)
     );
     vfs.with_user_data(&Path::new("foo"), |u| {

--- a/rls/src/config.rs
+++ b/rls/src/config.rs
@@ -223,11 +223,9 @@ impl Config {
             let seq = serde::de::value::MapDeserializer::new(map.iter().filter_map(|(k, v)| {
                 use heck::SnakeCase;
                 let snake_case = k.to_snake_case();
-                let (_, ref mut vec) = dups
-                    .raw_entry_mut()
-                    .from_key(&snake_case)
-                    .or_insert(snake_case.clone(), vec![]);
+                let vec = dups.entry(snake_case.clone()).or_default();
                 vec.push(k.to_string());
+
                 if vec.len() == 1 {
                     Some((snake_case, JsonValue(v.to_owned().clone())))
                 } else {

--- a/rls/src/lib.rs
+++ b/rls/src/lib.rs
@@ -5,8 +5,7 @@
 //! functionality such as 'goto definition', symbol search, reformatting, and
 //! code completion, and enables renaming and refactorings.
 
-#![feature(rustc_private, integer_atomics, drain_filter, hash_raw_entry)]
-#![allow(unknown_lints)]
+#![feature(rustc_private, drain_filter)]
 #![warn(clippy::all, rust_2018_idioms)]
 #![allow(clippy::cyclomatic_complexity, clippy::too_many_arguments)]
 


### PR DESCRIPTION
Simple chore, removing `crate_visibility_modifier` since it didn't make the cut to Rust 2018.

@nrc IIRC someone wanted to use rls-analysis in a stable setting (although the file format continues to be very unstable) so maybe it might be a good idea to release new versions of those packages from this monorepo.