### PR TITLE
Apply Clippy fixes

### DIFF
--- a/rls/src/actions/format.rs
+++ b/rls/src/actions/format.rs
@@ -135,7 +135,7 @@ fn rustfmt_args(config: &Config, config_path: &Path) -> Vec<String> {
     args.push(lines);
 
     args.push("--config-path".into());
-    args.push(config_path.to_str().map(|x| x.to_string()).unwrap());
+    args.push(config_path.to_str().map(ToOwned::to_owned).unwrap());
 
     args
 }

--- a/rls/src/actions/hover.rs
+++ b/rls/src/actions/hover.rs
@@ -161,7 +161,7 @@ pub fn extract_docs(
             break;
         } else if line.starts_with("///") || line.starts_with("//!") {
             let pos =
-                if line.chars().nth(3).map(|c| c.is_whitespace()).unwrap_or(false) { 4 } else { 3 };
+                if line.chars().nth(3).map(char::is_whitespace).unwrap_or(false) { 4 } else { 3 };
             let doc_line = line[pos..].into();
             if up {
                 docs.insert(0, doc_line);
@@ -632,9 +632,9 @@ fn racer_match_to_def(ctx: &InitActionContext, m: &racer::Match) -> Option<Def> 
             .or_else(|| skip_path_components(&contextstr_path, cargo_home, 3))
             // Make the path relative to the root of the project, if possible.
             .or_else(|| {
-                contextstr_path.strip_prefix(&ctx.current_project).ok().map(|x| x.to_owned())
+                contextstr_path.strip_prefix(&ctx.current_project).ok().map(ToOwned::to_owned)
             })
-            .and_then(|path| path.to_str().map(|s| s.to_string()))
+            .and_then(|path| path.to_str().map(ToOwned::to_owned))
             .unwrap_or_else(|| contextstr.to_string())
     } else {
         m.contextstr.trim_end_matches('{').trim().to_string()
@@ -695,7 +695,7 @@ fn racer_def(ctx: &InitActionContext, span: &Span<ZeroIndexed>) -> Option<Def> {
     let name = vfs.load_line(file_path.as_path(), span.range.row_start).ok().and_then(|line| {
         let col_start = span.range.col_start.0 as usize;
         let col_end = span.range.col_end.0 as usize;
-        line.get(col_start..col_end).map(|line| line.to_string())
+        line.get(col_start..col_end).map(ToOwned::to_owned)
     });
 
     debug!("racer_def: name: {:?}", name);

--- a/rls/src/actions/mod.rs
+++ b/rls/src/actions/mod.rs
@@ -512,7 +512,7 @@ impl FileWatch {
         // Find any Cargo.tomls in the project
         for entry in WalkDir::new(project_str)
             .into_iter()
-            .filter_map(|e| e.ok())
+            .filter_map(Result::ok)
             .filter(|e| e.file_name() == "Cargo.toml")
         {
             watchers.push(watcher(entry.path().display().to_string()));

--- a/rls/src/actions/requests.rs
+++ b/rls/src/actions/requests.rs
@@ -566,7 +566,7 @@ fn make_deglob_actions(
 
 // Ideally we'd use Rustfmt for this, but reparsing is a bit of a pain.
 fn sort_deglob_str(s: &str) -> String {
-    let mut substrings = s.split(',').map(|s| s.trim()).collect::<Vec<_>>();
+    let mut substrings = s.split(',').map(str::trim).collect::<Vec<_>>();
     substrings.sort_by(|a, b| {
         use std::cmp::Ordering;
 

--- a/rls/src/build/cargo.rs
+++ b/rls/src/build/cargo.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use cargo::core::compiler::{BuildConfig, CompileMode, Context, Executor, Unit};
+use cargo::core::Package;
 use cargo::core::resolver::ResolveError;
 use cargo::core::{
     enable_nightly_features, PackageId, Shell, Target, TargetKind, Verbosity, Workspace,
@@ -321,7 +322,7 @@ impl RlsExecutor {
         progress_sender: Sender<ProgressUpdate>,
         reached_primary: Arc<AtomicBool>,
     ) -> RlsExecutor {
-        let member_packages = ws.members().map(|x| x.package_id()).collect();
+        let member_packages = ws.members().map(Package::package_id).collect();
 
         RlsExecutor {
             compilation_cx,
@@ -521,7 +522,7 @@ impl Executor for RlsExecutor {
         {
             let mut compilation_cx = self.compilation_cx.lock().unwrap();
             compilation_cx.needs_rebuild = false;
-            compilation_cx.cwd = cargo_cmd.get_cwd().map(|p| p.to_path_buf());
+            compilation_cx.cwd = cargo_cmd.get_cwd().map(ToOwned::to_owned);
         }
 
         let build_dir = {

--- a/rls/src/build/cargo_plan.rs
+++ b/rls/src/build/cargo_plan.rs
@@ -210,7 +210,7 @@ impl CargoPlan {
             })
             .collect();
 
-        for modified in files.iter().map(|x| x.as_ref()) {
+        for modified in files.iter().map(AsRef::as_ref) {
             if let Some(unit) = build_scripts.get(modified) {
                 result.insert(unit.clone());
             } else {
@@ -553,7 +553,7 @@ impl BuildGraph for CargoPlan {
     }
 
     fn topological_sort(&self, units: Vec<&Self::Unit>) -> Vec<&Self::Unit> {
-        let keys = units.into_iter().map(|u| u.key()).collect();
+        let keys = units.into_iter().map(BuildKey::key).collect();
         let graph = self.dirty_rev_dep_graph(&keys);
 
         CargoPlan::topological_sort(self, &graph)

--- a/rls/src/build/plan.rs
+++ b/rls/src/build/plan.rs
@@ -151,7 +151,7 @@ impl JobQueue {
 
             // Send a window/progress notification.
             {
-                let crate_name = proc_argument_value(&job, "--crate-name").and_then(|x| x.to_str());
+                let crate_name = proc_argument_value(&job, "--crate-name").and_then(OsStr::to_str);
                 let update = match crate_name {
                     Some(name) => {
                         let cfg_test = job.get_args().iter().any(|arg| arg == "--test");

--- a/rls/src/build/rustc.rs
+++ b/rls/src/build/rustc.rs
@@ -94,7 +94,7 @@ pub(crate) fn rustc(
             clippy_args.push("clippy::all".to_owned());
         }
 
-        args.iter().map(|s| s.to_owned()).chain(clippy_args).collect()
+        args.iter().map(ToOwned::to_owned).chain(clippy_args).collect()
     } else {
         args.to_owned()
     };

--- a/rls/src/lib.rs
+++ b/rls/src/lib.rs
@@ -7,7 +7,7 @@
 
 #![feature(rustc_private, drain_filter)]
 #![warn(clippy::all, rust_2018_idioms)]
-#![allow(clippy::cyclomatic_complexity, clippy::too_many_arguments)]
+#![allow(clippy::cyclomatic_complexity, clippy::too_many_arguments, clippy::redundant_closure)]
 
 pub use rls_analysis::{AnalysisHost, Target};
 pub use rls_vfs::Vfs;

--- a/rls/src/project_model.rs
+++ b/rls/src/project_model.rs
@@ -182,7 +182,7 @@ impl racer::ProjectModelProvider for RacerProjectModel {
         }
         let dep = pkg.deps(&self.0).iter().find(|dep| dep.crate_name == libname)?.pkg;
 
-        dep.lib_root(&self.0).map(|p| p.to_owned())
+        dep.lib_root(&self.0).map(ToOwned::to_owned)
     }
 }
 

--- a/rls/src/server/message.rs
+++ b/rls/src/server/message.rs
@@ -338,7 +338,7 @@ impl RawMessage {
         // (Null being unused value of param by the JSON-RPC 2.0 spec)
         // in order to unify the type handling –- now the parameter type implements
         // `Deserialize`.
-        let params = match ls_command.get("params").map(|p| p.to_owned()) {
+        let params = match ls_command.get("params").map(ToOwned::to_owned) {
             Some(params @ serde_json::Value::Object(..))
             | Some(params @ serde_json::Value::Array(..)) => params,
             // Null as input value is not allowed by JSON-RPC 2.0,

--- a/tests/support/client/mod.rs
+++ b/tests/support/client/mod.rs
@@ -82,6 +82,7 @@ impl Project {
 
         let (sink, stream) = LspFramed::from_transport(transport).split();
 
+        #[allow(clippy::unit_arg)] // We're interested in the side-effects of `process_msg`.
         let reader = stream
             .timeout(rls_timeout())
             .map_err(|_| ())


### PR DESCRIPTION
This is mostly due to `clippy::redundant_closure` which might make sense in most
cases but in other we'd like to let type inference do the work for a
concise and readable code (e.g. `toml::de::Error::line_col` instead of
`|x| x.line_col()`).