### PR TITLE
Return only modified lines in formatting responses

### DIFF
--- a/rls/src/actions/format.rs
+++ b/rls/src/actions/format.rs
@@ -86,9 +86,8 @@ impl Rustfmt {
             .map(|item| {
                 // Rustfmt's line indices are 1-based
                 let start_line = u64::from(item.line_number_orig) - 1;
-                let removed = u64::from(item.lines_removed);
-                // If there is only one line and we add them, we may underflow.
-                let removed = if removed == 0 { 0 } else { removed - 1 };
+                // Could underflow if we don't remove lines and there's only one
+                let removed = u64::from(item.lines_removed).saturating_sub(1);
                 TextEdit {
                     range: Range {
                         start: Position::new(start_line, 0),

--- a/rls/src/actions/requests.rs
+++ b/rls/src/actions/requests.rs
@@ -725,7 +725,7 @@ fn reformat(
     let formatted_text = ctx
         .formatter()
         .format(input, config)
-        .map_err(|msg| ResponseError::Message(ErrorCode::InternalError, msg))?;
+        .map_err(|msg| ResponseError::Message(ErrorCode::InternalError, msg.to_string()))?;
 
     // Note that we don't need to update the VFS, the client echos back the
     // change to us when it applies the returned `TextEdit`.

--- a/rls/src/lib.rs
+++ b/rls/src/lib.rs
@@ -9,6 +9,9 @@
 #![warn(clippy::all, rust_2018_idioms)]
 #![allow(clippy::cyclomatic_complexity, clippy::too_many_arguments, clippy::redundant_closure)]
 
+#[macro_use]
+extern crate failure;
+
 pub use rls_analysis::{AnalysisHost, Target};
 pub use rls_vfs::Vfs;
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1765,7 +1765,7 @@ fn client_reformat() {
             start: Position { line: 0, character: 0 },
             end: Position { line: 2, character: 0 },
         },
-        new_text: "pub mod foo;\npub fn main() {\n    let world = \"world\";\n    println!(\"Hello, {}!\", world);\n}\n".to_string(),
+        new_text: "pub mod foo;\npub fn main() {\n    let world = \"world\";\n    println!(\"Hello, {}!\", world);\n}".to_string(),
     });
 }
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1802,17 +1802,14 @@ fn client_reformat_with_range() {
     let newline = if cfg!(windows) { "\r\n" } else { "\n" };
     let formatted = r#"pub fn main() {
     let world1 = "world";
-    println!("Hello, {}!", world1);
-
-// Work around rustfmt#3494
-let world2 = "world"; println!("Hello, {}!", world2);
-let world3 = "world"; println!("Hello, {}!", world3);
-    }
-"#
+    println!("Hello, {}!", world1);"#
     .replace("\r", "")
     .replace("\n", newline);
 
-    assert_eq!(result.unwrap()[0].new_text, formatted);
+    let edits = result.unwrap();
+    assert_eq!(edits.len(), 2);
+    assert_eq!(edits[0].new_text, formatted);
+    assert_eq!(edits[1].new_text, "");
 }
 
 #[test]

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1763,7 +1763,7 @@ fn client_reformat() {
     assert_eq!(result.unwrap()[0], TextEdit {
         range: Range {
             start: Position { line: 0, character: 0 },
-            end: Position { line: 2, character: 0 },
+            end: Position { line: 1, character: u64::max_value() },
         },
         new_text: "pub mod foo;\npub fn main() {\n    let world = \"world\";\n    println!(\"Hello, {}!\", world);\n}".to_string(),
     });


### PR DESCRIPTION
Ticks few boxes in #3. (that's an early issue!)
Closes #334.

This is currently based on https://github.com/rust-lang/rustfmt/pull/3424 and so currently blocked until it merges.

Configures Rustfmt to use `EmitMode::ModifiedLines` and parses the response - this should work with both statically-linked and externally provided Rustfmt.

@alexheretic do you think you could take a look and double-check?