### PR TITLE
Update cargo and clippy.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,14 +126,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "cargo"
 version = "0.35.0"
-source = "git+https://github.com/rust-lang/cargo?rev=4e74e2fc0908524d17735c768067117d3e84ee9c#4e74e2fc0908524d17735c768067117d3e84ee9c"
+source = "git+https://github.com/rust-lang/cargo?rev=716b02cb4c7b75ce435eb06defa25bc2d725909c#716b02cb4c7b75ce435eb06defa25bc2d725909c"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crates-io 0.23.0 (git+https://github.com/rust-lang/cargo?rev=4e74e2fc0908524d17735c768067117d3e84ee9c)",
+ "crates-io 0.23.0 (git+https://github.com/rust-lang/cargo?rev=716b02cb4c7b75ce435eb06defa25bc2d725909c)",
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-hash 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -217,7 +217,7 @@ dependencies = [
 [[package]]
 name = "clippy_lints"
 version = "0.0.212"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=f69ec96906d300132ffd33151bf6641b950db96d#f69ec96906d300132ffd33151bf6641b950db96d"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=caccf8bd4c3d490d6a4cf329a3411bbf68753642#caccf8bd4c3d490d6a4cf329a3411bbf68753642"
 dependencies = [
  "cargo_metadata 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "if_chain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -282,7 +282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "crates-io"
 version = "0.23.0"
-source = "git+https://github.com/rust-lang/cargo?rev=4e74e2fc0908524d17735c768067117d3e84ee9c#4e74e2fc0908524d17735c768067117d3e84ee9c"
+source = "git+https://github.com/rust-lang/cargo?rev=716b02cb4c7b75ce435eb06defa25bc2d725909c#716b02cb4c7b75ce435eb06defa25bc2d725909c"
 dependencies = [
  "curl 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1414,9 +1414,9 @@ dependencies = [
 name = "rls"
 version = "1.34.0"
 dependencies = [
- "cargo 0.35.0 (git+https://github.com/rust-lang/cargo?rev=4e74e2fc0908524d17735c768067117d3e84ee9c)",
+ "cargo 0.35.0 (git+https://github.com/rust-lang/cargo?rev=716b02cb4c7b75ce435eb06defa25bc2d725909c)",
  "cargo_metadata 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy_lints 0.0.212 (git+https://github.com/rust-lang/rust-clippy?rev=f69ec96906d300132ffd33151bf6641b950db96d)",
+ "clippy_lints 0.0.212 (git+https://github.com/rust-lang/rust-clippy?rev=caccf8bd4c3d490d6a4cf329a3411bbf68753642)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2325,19 +2325,19 @@ dependencies = [
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"
-"checksum cargo 0.35.0 (git+https://github.com/rust-lang/cargo?rev=4e74e2fc0908524d17735c768067117d3e84ee9c)" = "<none>"
+"checksum cargo 0.35.0 (git+https://github.com/rust-lang/cargo?rev=716b02cb4c7b75ce435eb06defa25bc2d725909c)" = "<none>"
 "checksum cargo_metadata 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "585784cac9b05c93a53b17a0b24a5cdd1dfdda5256f030e089b549d2390cc720"
 "checksum cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)" = "4390a3b5f4f6bce9c1d0c00128379df433e53777fdd30e92f16a529332baec4e"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
-"checksum clippy_lints 0.0.212 (git+https://github.com/rust-lang/rust-clippy?rev=f69ec96906d300132ffd33151bf6641b950db96d)" = "<none>"
+"checksum clippy_lints 0.0.212 (git+https://github.com/rust-lang/rust-clippy?rev=caccf8bd4c3d490d6a4cf329a3411bbf68753642)" = "<none>"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum commoncrypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
 "checksum commoncrypto-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e2640d6d0bf22e82bed1b73c6aef8d5dd31e5abe6666c57e6d45e2649f4f887"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
-"checksum crates-io 0.23.0 (git+https://github.com/rust-lang/cargo?rev=4e74e2fc0908524d17735c768067117d3e84ee9c)" = "<none>"
+"checksum crates-io 0.23.0 (git+https://github.com/rust-lang/cargo?rev=716b02cb4c7b75ce435eb06defa25bc2d725909c)" = "<none>"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crc32fast 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e91d5240c6975ef33aeb5f148f35275c25eda8e8a5f95abe421978b05b8bf192"
 "checksum crossbeam 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad4c7ea749d9fb09e23c5cb17e3b70650860553a0e2744e38446b1803bf7db94"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ rls-rustc = "0.5.0"
 rls-span = { version = "0.4", features = ["serialize-serde"] }
 rls-vfs = "0.7"
 
-cargo = { git = "https://github.com/rust-lang/cargo", rev = "4e74e2fc0908524d17735c768067117d3e84ee9c" }
+cargo = { git = "https://github.com/rust-lang/cargo", rev = "716b02cb4c7b75ce435eb06defa25bc2d725909c" }
 cargo_metadata = "0.7"
-clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "f69ec96906d300132ffd33151bf6641b950db96d", optional = true }
+clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "caccf8bd4c3d490d6a4cf329a3411bbf68753642", optional = true }
 env_logger = "0.6"
 failure = "0.1.1"
 home = "0.3"

--- a/rls/src/build/cargo.rs
+++ b/rls/src/build/cargo.rs
@@ -206,7 +206,7 @@ fn run_cargo_ws(
 
     let compile_opts = CompileOptions {
         spec,
-        filter: CompileFilter::new(
+        filter: CompileFilter::from_raw_arguments(
             opts.lib,
             opts.bin,
             opts.bins,


### PR DESCRIPTION
Cargo had a minor api change due to rust-lang/cargo#6683.

Clippy needed an update to build with latest nightly.
