### PR TITLE
Add serde implementation to complement rustc-serialize

### DIFF
--- a/rls-analysis/Cargo.toml
+++ b/rls-analysis/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 ]
 
 [dependencies]
-rustc-serialize = "0.3"
+rustc-serialize = { version = "0.3", optional = true }
 log = "0.4"
 rls-data = "= 0.18.2"
 rls-span = "0.4"
@@ -19,7 +19,14 @@ derive-new = "0.5"
 fst = { version = "0.3", default-features = false }
 itertools = "0.7.3"
 json = "0.11.13"
+serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
 lazy_static = "1"
 env_logger = "0.5"
+
+[features]
+default = ["serialize-rustc"]
+serialize-rustc = ["rustc-serialize", "rls-data/serialize-rustc", "rls-span/serialize-rustc"]
+serialize-serde = ["serde", "serde_json", "rls-data/serialize-serde", "rls-span/serialize-serde"]

--- a/rls-analysis/src/lib.rs
+++ b/rls-analysis/src/lib.rs
@@ -15,7 +15,12 @@ extern crate itertools;
 extern crate json;
 extern crate rls_data as data;
 extern crate rls_span as span;
+#[cfg(feature = "serialize-rustc")]
 extern crate rustc_serialize;
+#[cfg(feature = "serialize-serde")]
+extern crate serde;
+#[cfg(feature = "serialize-serde")]
+extern crate serde_json;
 
 mod analysis;
 mod listings;

--- a/rls-analysis/src/raw.rs
+++ b/rls-analysis/src/raw.rs
@@ -123,7 +123,7 @@ fn read_crate_data(path: &Path) -> Option<Analysis> {
             Err(err)
         })
         .ok()?;
-    let s = ::rustc_serialize::json::decode(&buf)
+    let s = read_analysis(&buf)
         .or_else(|err| {
             warn!("deserialisation error: {:?}", err);
             json::parse(&buf)
@@ -155,6 +155,16 @@ fn read_crate_data(path: &Path) -> Option<Analysis> {
     info!("reading {:?} {}.{:09}s", path, d.as_secs(), d.subsec_nanos());
 
     s
+}
+
+#[cfg(feature = "serialize-rustc")]
+fn read_analysis(buf: &String) -> Result<Option<Analysis>, rustc_serialize::json::DecoderError> {
+    ::rustc_serialize::json::decode(&buf)
+}
+
+#[cfg(feature = "serialize-serde")]
+fn read_analysis(buf: &String) -> Result<Option<Analysis>, serde_json::Error> {
+    ::serde_json::from_str(buf)
 }
 
 pub fn name_space_for_def_kind(dk: DefKind) -> char {

--- a/rls-analysis/src/raw.rs
+++ b/rls-analysis/src/raw.rs
@@ -158,12 +158,12 @@ fn read_crate_data(path: &Path) -> Option<Analysis> {
 }
 
 #[cfg(feature = "serialize-rustc")]
-fn read_analysis(buf: &String) -> Result<Option<Analysis>, rustc_serialize::json::DecoderError> {
-    ::rustc_serialize::json::decode(&buf)
+fn read_analysis(buf: &str) -> Result<Option<Analysis>, rustc_serialize::json::DecoderError> {
+    ::rustc_serialize::json::decode(buf)
 }
 
 #[cfg(feature = "serialize-serde")]
-fn read_analysis(buf: &String) -> Result<Option<Analysis>, serde_json::Error> {
+fn read_analysis(buf: &str) -> Result<Option<Analysis>, serde_json::Error> {
     ::serde_json::from_str(buf)
 }
 

--- a/rls-analysis/src/raw.rs
+++ b/rls-analysis/src/raw.rs
@@ -123,7 +123,7 @@ fn read_crate_data(path: &Path) -> Option<Analysis> {
             Err(err)
         })
         .ok()?;
-    let s = read_analysis(&buf)
+    let s = decode_buf(&buf)
         .or_else(|err| {
             warn!("deserialisation error: {:?}", err);
             json::parse(&buf)
@@ -158,12 +158,12 @@ fn read_crate_data(path: &Path) -> Option<Analysis> {
 }
 
 #[cfg(feature = "serialize-rustc")]
-fn read_analysis(buf: &str) -> Result<Option<Analysis>, rustc_serialize::json::DecoderError> {
+fn decode_buf(buf: &str) -> Result<Option<Analysis>, rustc_serialize::json::DecoderError> {
     ::rustc_serialize::json::decode(buf)
 }
 
 #[cfg(feature = "serialize-serde")]
-fn read_analysis(buf: &str) -> Result<Option<Analysis>, serde_json::Error> {
+fn decode_buf(buf: &str) -> Result<Option<Analysis>, serde_json::Error> {
     ::serde_json::from_str(buf)
 }
 


### PR DESCRIPTION
We want to transition off of rustc-serialize and onto serde, so this
commit sets up both to co-exist, gated by feature flags. Due to the fact
that they implement the same functions, only one feature flag can be
active at a time. To compile rls-analysis with serde, it is necessary to
run cargo build with the `--no-default-features` flag and the
`--features "serialize-serde"` flag.

The tests in this commit will still work with the default feature flags
but will need to be changed before the serde implementation can pass
tests.

Addresses #1354