### PR TITLE
Remove now-unnecessary `link_args`

### DIFF
--- a/rls/src/main.rs
+++ b/rls/src/main.rs
@@ -5,13 +5,6 @@
 //! functionality such as 'goto definition', symbol search, reformatting, and
 //! code completion, and enables renaming and refactorings.
 
-// See rustc/rustc.rs in rust repo for explanation of stack adjustments.
-#![feature(link_args)]
-#[allow(unused_attributes)]
-#[cfg_attr(all(windows, target_env = "msvc"), link_args = "/STACK:16777216")]
-#[cfg_attr(all(windows, not(target_env = "msvc")), link_args = "-Wl,--stack,16777216")]
-extern "C" {}
-
 use log::warn;
 use rls_rustc as rustc_shim;
 


### PR DESCRIPTION
Previously this was put here to fix stack overflow on Windows: https://github.com/rust-lang/rls/pull/942

In Rust this was removed as part of the https://github.com/rust-lang/rust/pull/56732. @Zoxc could you tell why this was removed? Is that not necessary now, with the underlying architecture changes to the compiler?