### PR TITLE
Bump RLS version to 1.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "rls"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "cargo 0.35.0 (git+https://github.com/rust-lang/cargo?rev=716b02cb4c7b75ce435eb06defa25bc2d725909c)",
  "cargo_metadata 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rls"
-version = "1.34.0"
+version = "1.35.0"
 edition = "2018"
 authors = ["Nick Cameron <ncameron@mozilla.com>", "The RLS developers"]
 description = "Rust Language Server - provides information about Rust programs to IDEs and other tools"


### PR DESCRIPTION
In order to match the current nightly Rust version.