### PR TITLE
Use serde instead of rustc_serialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,7 +1403,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-analysis 0.16.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rls-analysis 0.16.12",
  "rls-blacklist 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-data 0.18.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-rustc 0.6.0",
@@ -1429,7 +1429,6 @@ dependencies = [
 [[package]]
 name = "rls-analysis"
 version = "0.16.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fst 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1438,7 +1437,8 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-data 0.18.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2434,7 +2434,6 @@ dependencies = [
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
-"checksum rls-analysis 0.16.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ae18d8ad01dec3b2014f4d7ae3c607d7adbcff79e5d3b48ea42ea71c10d43a71"
 "checksum rls-blacklist 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ce1fdac03e138c4617ff87b194e1ff57a39bb985a044ccbd8673d30701e411"
 "checksum rls-data 0.18.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5f80b84551b32e26affaf7f12374913b5061730c0dcd185d9e8fa5a15e36e65c"
 "checksum rls-span 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "33d66f1d6c6ccd5c98029f162544131698f6ebb61d8c697681cac409dcd08805"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,7 +1403,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rls-analysis 0.16.12",
+ "rls-analysis 0.16.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-blacklist 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-data 0.18.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-rustc 0.6.0",
@@ -1428,7 +1428,8 @@ dependencies = [
 
 [[package]]
 name = "rls-analysis"
-version = "0.16.12"
+version = "0.16.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fst 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2434,6 +2435,7 @@ dependencies = [
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum rls-analysis 0.16.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6b7a3313d47232b586365b52a776ccf6ea903d1ec157c84ed2bb54d7f1ef6503"
 "checksum rls-blacklist 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ce1fdac03e138c4617ff87b194e1ff57a39bb985a044ccbd8673d30701e411"
 "checksum rls-data 0.18.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5f80b84551b32e26affaf7f12374913b5061730c0dcd185d9e8fa5a15e36e65c"
 "checksum rls-span 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "33d66f1d6c6ccd5c98029f162544131698f6ebb61d8c697681cac409dcd08805"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,10 @@ test = false
 path = "rls/src/main.rs"
 
 [dependencies]
-rls-analysis = "0.16.12"
+# TODO: Use 0.16.13 from crates.io with "serialize-serde" feature when published
+rls-analysis = { version = "0.16.12", path = "rls-analysis", features = ["serialize-serde"], default-features = false }
 rls-blacklist = "0.1.3"
-rls-data = { version = "0.18.2", features = ["serialize-serde", "serialize-rustc"] }
+rls-data = { version = "0.18.2", features = ["serialize-serde"] }
 # FIXME: Release rls-rustc 0.6.0 to crates.io
 rls-rustc = { version = "0.6.0", path = "rls-rustc" }
 rls-span = { version = "0.4", features = ["serialize-serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,7 @@ test = false
 path = "rls/src/main.rs"
 
 [dependencies]
-# TODO: Use 0.16.13 from crates.io with "serialize-serde" feature when published
-rls-analysis = { version = "0.16.12", path = "rls-analysis", features = ["serialize-serde"], default-features = false }
+rls-analysis = { version = "0.16.13", features = ["serialize-serde"], default-features = false }
 rls-blacklist = "0.1.3"
 rls-data = { version = "0.18.2", features = ["serialize-serde"] }
 # FIXME: Release rls-rustc 0.6.0 to crates.io

--- a/rls/src/build/external.rs
+++ b/rls/src/build/external.rs
@@ -106,7 +106,7 @@ where
         let mut contents = String::new();
         file.read_to_string(&mut contents).map_err(|e| e.to_string())?;
 
-        let data = rustc_serialize::json::decode(&contents).map_err(|e| e.to_string())?;
+        let data = serde_json::from_str(&contents).map_err(|e| e.to_string())?;
         analyses.push(data);
     }
 


### PR DESCRIPTION
Basically #1435 but opened from the local (non-fork) branch since Rust tidy only whitelists this repository.

When/if https://github.com/rust-lang/rust/pull/60053 is merged, this should  be as well to retain Rust commit history continuity.