### PR TITLE
Preallocate clippy's symbol table

### DIFF
--- a/rls-rustc/src/lib.rs
+++ b/rls-rustc/src/lib.rs
@@ -33,7 +33,7 @@ pub fn run() {
             })
             .collect::<Vec<_>>();
 
-        run_compiler(&args, &mut ShimCalls, None, None)
+        run_compiler(&args, &[], &mut ShimCalls, None, None)
     })
     .and_then(|result| result);
     process::exit(result.is_err() as i32);

--- a/rls/src/build/rustc.rs
+++ b/rls/src/build/rustc.rs
@@ -114,6 +114,7 @@ pub(crate) fn rustc(
             // Replace stderr so we catch most errors.
             run_compiler(
                 &args,
+                &clippy_lints::PREINTERNED_SYMBOLS,
                 &mut callbacks,
                 Some(Box::new(ReplacedFileLoader::new(changed))),
                 Some(Box::new(BufWriter(buf))),


### PR DESCRIPTION
@Xanewok can you put this into a branch so I can point a rustc submodule at it?

rust PR: https://github.com/rust-lang/rust/pull/60907