### PR TITLE
Make ripgrep ignore test data JSON files

### DIFF
--- a/rls-analysis/test_data/.ignore
+++ b/rls-analysis/test_data/.ignore
@@ -1,0 +1,2 @@
+/rls-analysis
+/rust-analysis


### PR DESCRIPTION
CC https://github.com/BurntSushi/ripgrep/issues/1284

Without this, running for example `rg ptr::NonNull` in the Rust repository floods the console with the entire contents of `src/tools/rls/rls-analysis/test_data/rust-analysis/libcore-a5db6a3445116c08.json`, which is a 3 MB single-line JSON file.