### PR TITLE
Fix contributing.md env_logger example

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -133,7 +133,7 @@ VSCode - select "Rust Language Server" from the drop down box ("Rust Language
 Server" will only show up if there is any debugging output from RLS). Do not
 write to stdout, that will cause LSP errors (this means you cannot
 `println`). You can enable logging using
-[RUST_LOG](https://doc.rust-lang.org/log/env_logger/) environment variable
+[RUST_LOG](https://docs.rs/env_logger/) environment variable
 (e.g. `RUST_LOG=rls=debug code`). For adding your own, temporary logging you may
 find the `eprintln` macro useful.
 


### PR DESCRIPTION
A very small PR to the contributing.md file:

1. The link to the env_logger crate was broken: `The requested resource does not exist`
2. The example environment variable threw an error: `warning: invalid logging spec 'debug code', ignoring it` (I removed the `code`  from `RUST_LOG=rls=debug code`)

It's not much but I bumped into it and had to figure it out, it'll maybe save a few minutes to other people :)