### PR TITLE
Do not build Clippy by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: rust
 dist: xenial
 cache:
   cargo: false
-os:
-  - linux
-  - osx
-  - windows
 rust:
   - nightly
 install:
@@ -13,19 +9,33 @@ install:
   # Required for Racer autoconfiguration
   - rustup component add rust-src
   - rustup component add rust-analysis
+matrix:
+  fast_finish: true
+  include:
+    - os: linux
+    - os: osx
+    - os: windows
+    - env: CLIPPY=true
+      if: commit_message =~ /(?i:^update.*\b(clippy)\b)/
 script:
-  # Since the rls-* subcrates use crates.io-based dependencies of themselves it
-  # makes sense to test them in isolation rather than just RLS itself
-  - (cd rls-analysis && cargo test -v && cargo fmt -- --check)
-  - (cd rls-blacklist && cargo test -v && cargo fmt -- --check)
-  - (cd rls-data && cargo test -v && cargo fmt -- --check)
-  - (cd rls-rustc && cargo test -v && cargo fmt -- --check)
-  - (cd rls-span && cargo test -v && cargo fmt -- --check)
-  - (cd rls-vfs && cargo test -v && cargo fmt -- --check)
-  - cargo fmt -- --check
-  - cargo build -v
-  - cargo test -v
-  - cargo test test_tooltip_std -- --ignored
+  - |
+    if [ ${CLIPPY} = true ]; then
+      cargo build -v --features "clippy"
+      cargo test -v --features "clippy"
+    else
+      # Since the rls-* subcrates use crates.io-based dependencies of themselves it
+      # makes sense to test them in isolation rather than just RLS itself
+      (cd rls-analysis && cargo test -v && cargo fmt -- --check)
+      (cd rls-blacklist && cargo test -v && cargo fmt -- --check)
+      (cd rls-data && cargo test -v && cargo fmt -- --check)
+      (cd rls-rustc && cargo test -v && cargo fmt -- --check)
+      (cd rls-span && cargo test -v && cargo fmt -- --check)
+      (cd rls-vfs && cargo test -v && cargo fmt -- --check)
+      cargo fmt -- --check
+      cargo build -v
+      cargo test -v
+      cargo test test_tooltip_std -- --ignored
+    fi
 
 env:
   global:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,5 +77,4 @@ tokio-timer = "0.2"
 rustc_tools_util = "0.1.1"
 
 [features]
-default = ["clippy"]
 clippy = ["clippy_lints"]


### PR DESCRIPTION
For https://github.com/rust-lang/rust/issues/59761

As the bonus I changed Travis to test Clippy only when commit message contains words `update`, `clippy`. You can see it in the action here: https://travis-ci.com/mati865/rls/builds/114715073 https://travis-ci.com/mati865/rls/builds/114715514
That trick was borrowed from Rust: https://github.com/rust-lang/rust/blob/ca1bcfdde3f19afd68ef808cecf2ce56d08d5df4/.travis.yml#L218