### PR TITLE
Clear CARGO_TARGET_DIR for tests.

### DIFF
--- a/tests/support/client/mod.rs
+++ b/tests/support/client/mod.rs
@@ -59,6 +59,10 @@ impl Project {
         let mut cmd = Command::new(rls_exe());
         cmd.current_dir(self.root());
         cmd.stderr(Stdio::inherit());
+        // If `CARGO_TARGET_DIR` is set (such as in rust-lang/rust), don't
+        // reuse it. Each test needs its own target directory so they don't
+        // stomp on each other's files.
+        cmd.env_remove("CARGO_TARGET_DIR");
 
         cmd
     }


### PR DESCRIPTION
Setting `CARGO_TARGET_DIR=somedir cargo test` would cause every test to reuse the same target dir, causing them to stomp on each other's files.  This changes it so that `CARGO_TARGET_DIR` is cleared, and each invocation of rls in the tests will use the target directory in the project where it runs.

Fixes #1466.
