### PR TITLE
fix(cmd): make clear_env_rust_log default to false

### DIFF
--- a/rls/src/cmd.rs
+++ b/rls/src/cmd.rs
@@ -364,7 +364,8 @@ fn init() -> Sender<String> {
     let service = LsService::new(
         analysis,
         vfs,
-        Arc::new(Mutex::new(Config::default())),
+        // Don't clear `RUST_LOG` in CLI mode since it's intended for debugging purposes.
+        Arc::new(Mutex::new(Config { clear_env_rust_log: false, ..Default::default() })),
         Box::new(ChannelMsgReader::new(receiver)),
         PrintlnOutput,
     );


### PR DESCRIPTION
Since the CLI is intended for debugging purposes.