### PR TITLE
Ensure that --error-format is only passed once to `rustc`

### DIFF
--- a/rls/src/build/cargo.rs
+++ b/rls/src/build/cargo.rs
@@ -391,9 +391,9 @@ impl Executor for RlsExecutor {
         _on_stdout_line: &mut dyn FnMut(&str) -> CargoResult<()>,
         _on_stderr_line: &mut dyn FnMut(&str) -> CargoResult<()>,
     ) -> CargoResult<()> {
-        // Use JSON output so that we can parse the rustc output.
-        // Filter first to work around "--error-format" being passed with
-        // CARGO_PIPELINING(?) enabled in Cargo.
+        // Enforce JSON output so that we can parse the rustc output by
+        // stripping --error-format if it was specified (e.g. Cargo pipelined
+        // build)
         let filtered_args = filter_arg(cargo_cmd.get_args(), "--error-format");
         cargo_cmd.args_replace(&filtered_args);
         cargo_cmd.arg("--error-format=json");

--- a/rls/src/build/cargo.rs
+++ b/rls/src/build/cargo.rs
@@ -392,6 +392,10 @@ impl Executor for RlsExecutor {
         _on_stderr_line: &mut dyn FnMut(&str) -> CargoResult<()>,
     ) -> CargoResult<()> {
         // Use JSON output so that we can parse the rustc output.
+        // Filter first to work around "--error-format" being passed with
+        // CARGO_PIPELINING(?) enabled in Cargo.
+        let filtered_args = filter_arg(cargo_cmd.get_args(), "--error-format");
+        cargo_cmd.args_replace(&filtered_args);
         cargo_cmd.arg("--error-format=json");
         // Delete any stale data. We try and remove any json files with
         // the same crate name as Cargo would emit. This includes files
@@ -753,6 +757,18 @@ fn dedup_flags(flag_str: &str) -> String {
         }
     }
     result
+}
+
+fn filter_arg(args: &[OsString], key: &str) -> Vec<String> {
+    let key_as_prefix = key.to_owned() + "=";
+    args.iter()
+        .zip(vec!["".into()].iter().chain(args.iter()))
+        .filter_map(|(x, prev)| {
+            x.to_str()
+                .filter(|x| !x.starts_with(&key_as_prefix) && prev != key)
+                .map(|x| x.to_string())
+        })
+        .collect()
 }
 
 /// Error wrapper that tries to figure out which manifest the cause best relates to in the project


### PR DESCRIPTION
Continuation of #1471, this builds on it by also filtering the `--FLAG VALUE` arguments and adding unit tests.

Closes #1471.

