### PR TITLE
Disable client_find_definitions

### DIFF
--- a/tests/client.rs
+++ b/tests/client.rs
@@ -995,6 +995,7 @@ fn client_lens_run() {
 }
 
 #[test]
+#[ignore] // Spurious in Rust CI, https://github.com/rust-lang/rust/issues/62225
 fn client_find_definitions() {
     const SRC: &str = r#"
         struct Foo {


### PR DESCRIPTION
Since switching CI to Azure Pipelines it seems that this test seems
to fail more consistently, so let's disable that for now. It helps
that we have less than a week before release - we disallow PRs that
break the tools to land in this period, so this makes landing critical
PRs smoother now.