### PR TITLE
Summer cleaning

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,3 @@
-// Copyright 2016-2017 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 use std::env;
 use std::path::Path;
 

--- a/rls-analysis/Cargo.toml
+++ b/rls-analysis/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rls-analysis"
 version = "0.17.0"
+edition = "2018"
 authors = ["Nick Cameron <ncameron@mozilla.com>"]
 description = "Library for processing rustc's save-analysis data for the RLS"
 license = "Apache-2.0/MIT"

--- a/rls-analysis/benches/std_api_crate.rs
+++ b/rls-analysis/benches/std_api_crate.rs
@@ -1,11 +1,3 @@
-// Copyright 2017 The RLS Project Developers.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 #![feature(test)]
 
 extern crate rls_analysis;

--- a/rls-analysis/src/analysis.rs
+++ b/rls-analysis/src/analysis.rs
@@ -1,11 +1,3 @@
-// Copyright 2017 The RLS Project Developers.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 use fst;
 use std::collections::{HashMap, HashSet};
 use std::iter;

--- a/rls-analysis/src/analysis.rs
+++ b/rls-analysis/src/analysis.rs
@@ -12,8 +12,8 @@ use std::iter;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-use raw::{CrateId, DefKind};
-use {Id, Span, SymbolQuery};
+use crate::raw::{CrateId, DefKind};
+use crate::{Id, Span, SymbolQuery};
 
 /// This is the main database that contains all the collected symbol information,
 /// such as definitions, their mapping between spans, hierarchy and so on,

--- a/rls-analysis/src/lib.rs
+++ b/rls-analysis/src/lib.rs
@@ -1,11 +1,3 @@
-// Copyright 2016 The RLS Project Developers.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 #![warn(rust_2018_idioms)]
 
 #[macro_use]

--- a/rls-analysis/src/lib.rs
+++ b/rls-analysis/src/lib.rs
@@ -6,17 +6,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![warn(rust_2018_idioms)]
+
 #[macro_use]
 extern crate derive_new;
 #[macro_use]
 extern crate log;
-extern crate fst;
-extern crate itertools;
-extern crate json;
+
 extern crate rls_data as data;
 extern crate rls_span as span;
-extern crate serde;
-extern crate serde_json;
 
 mod analysis;
 mod listings;
@@ -136,7 +134,7 @@ impl<L: AnalysisLoader> AnalysisHost<L> {
         analysis: Vec<data::Analysis>,
         path_prefix: &Path,
         base_dir: &Path,
-        blacklist: Blacklist,
+        blacklist: Blacklist<'_>,
     ) -> AResult<()> {
         self.reload_with_blacklist(path_prefix, base_dir, blacklist)?;
 
@@ -160,7 +158,7 @@ impl<L: AnalysisLoader> AnalysisHost<L> {
         &self,
         path_prefix: &Path,
         base_dir: &Path,
-        blacklist: Blacklist,
+        blacklist: Blacklist<'_>,
     ) -> AResult<()> {
         trace!("reload_with_blacklist {:?} {:?} {:?}", path_prefix, base_dir, blacklist);
         let empty = self.analysis.lock()?.is_none();
@@ -190,7 +188,7 @@ impl<L: AnalysisLoader> AnalysisHost<L> {
         &self,
         path_prefix: &Path,
         base_dir: &Path,
-        blacklist: Blacklist,
+        blacklist: Blacklist<'_>,
     ) -> AResult<()> {
         trace!("hard_reload {:?} {:?}", path_prefix, base_dir);
         // We're going to create a dummy AnalysisHost that we will fill with data,
@@ -551,7 +549,7 @@ impl<L: AnalysisLoader> AnalysisHost<L> {
 }
 
 impl ::std::fmt::Display for Id {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         self.0.fmt(f)
     }
 }
@@ -566,7 +564,7 @@ impl ::std::error::Error for AError {
 }
 
 impl ::std::fmt::Display for AError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(f, "{}", ::std::error::Error::description(self))
     }
 }

--- a/rls-analysis/src/listings/mod.rs
+++ b/rls-analysis/src/listings/mod.rs
@@ -1,11 +1,3 @@
-// Copyright 2016 The RLS Project Developers.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 use std::io;
 use std::path::Path;
 use std::time::SystemTime;

--- a/rls-analysis/src/loader.rs
+++ b/rls-analysis/src/loader.rs
@@ -1,11 +1,3 @@
-// Copyright 2017 The RLS Project Developers.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Defines an `AnalysisLoader` trait, which allows to specify directories
 //! from which save-analysis JSON files can be read. Also supplies a
 //! default implementation `CargoAnalysisLoader` for Cargo-emitted save-analysis

--- a/rls-analysis/src/loader.rs
+++ b/rls-analysis/src/loader.rs
@@ -17,7 +17,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use AnalysisHost;
+use crate::AnalysisHost;
 
 #[derive(Debug)]
 pub struct CargoAnalysisLoader {

--- a/rls-analysis/src/loader.rs
+++ b/rls-analysis/src/loader.rs
@@ -150,7 +150,7 @@ pub enum Target {
 }
 
 impl fmt::Display for Target {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Target::Release => write!(f, "release"),
             Target::Debug => write!(f, "debug"),

--- a/rls-analysis/src/lowering.rs
+++ b/rls-analysis/src/lowering.rs
@@ -9,12 +9,12 @@
 //! For processing the raw save-analysis data from rustc into the rls
 //! in-memory representation.
 
-use analysis::{Def, Glob, PerCrateAnalysis, Ref};
+use crate::analysis::{Def, Glob, PerCrateAnalysis, Ref};
 use data;
-use loader::AnalysisLoader;
-use raw::{self, CrateId, DefKind, RelationKind};
-use util;
-use {AResult, AnalysisHost, Id, Span, NULL};
+use crate::loader::AnalysisLoader;
+use crate::raw::{self, CrateId, DefKind, RelationKind};
+use crate::util;
+use crate::{AResult, AnalysisHost, Id, Span, NULL};
 
 use span;
 

--- a/rls-analysis/src/lowering.rs
+++ b/rls-analysis/src/lowering.rs
@@ -1,11 +1,3 @@
-// Copyright 2016 The RLS Project Developers.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! For processing the raw save-analysis data from rustc into the rls
 //! in-memory representation.
 

--- a/rls-analysis/src/raw.rs
+++ b/rls-analysis/src/raw.rs
@@ -12,8 +12,8 @@ pub use data::{
     CratePreludeData, Def, DefKind, GlobalCrateId as CrateId, Import, Ref, Relation, RelationKind,
     SigElement, Signature, SpanData,
 };
-use listings::{DirectoryListing, ListingKind};
-use {AnalysisLoader, Blacklist};
+use crate::listings::{DirectoryListing, ListingKind};
+use crate::{AnalysisLoader, Blacklist};
 
 use std::collections::HashMap;
 use std::fs::File;

--- a/rls-analysis/src/raw.rs
+++ b/rls-analysis/src/raw.rs
@@ -52,7 +52,7 @@ impl Crate {
 pub fn read_analysis_from_files<L: AnalysisLoader>(
     loader: &L,
     crate_timestamps: HashMap<PathBuf, SystemTime>,
-    crate_blacklist: Blacklist,
+    crate_blacklist: Blacklist<'_>,
 ) -> Vec<Crate> {
     let mut result = vec![];
 
@@ -99,7 +99,7 @@ pub fn read_analysis_from_files<L: AnalysisLoader>(
     result
 }
 
-fn ignore_data(file_name: &str, crate_blacklist: Blacklist) -> bool {
+fn ignore_data(file_name: &str, crate_blacklist: Blacklist<'_>) -> bool {
     crate_blacklist.iter().any(|name| file_name.starts_with(&format!("lib{}-", name)))
 }
 

--- a/rls-analysis/src/raw.rs
+++ b/rls-analysis/src/raw.rs
@@ -1,11 +1,3 @@
-// Copyright 2016 The RLS Project Developers.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 use data::config::Config;
 use data::Analysis;
 pub use data::{

--- a/rls-analysis/src/symbol_query.rs
+++ b/rls-analysis/src/symbol_query.rs
@@ -57,7 +57,7 @@ impl SymbolQuery {
         stream.union()
     }
 
-    pub(crate) fn search_stream<F, T>(&self, mut stream: fst::map::Union, f: F) -> Vec<T>
+    pub(crate) fn search_stream<F, T>(&self, mut stream: fst::map::Union<'_>, f: F) -> Vec<T>
     where
         F: Fn(&mut Vec<T>, &fst::map::IndexedValue),
     {

--- a/rls-analysis/src/test/mod.rs
+++ b/rls-analysis/src/test/mod.rs
@@ -13,9 +13,6 @@ use crate::{AnalysisHost, AnalysisLoader};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-#[cfg(test)]
-extern crate env_logger;
-
 #[derive(Clone, new)]
 struct TestAnalysisLoader {
     path: PathBuf,

--- a/rls-analysis/src/test/mod.rs
+++ b/rls-analysis/src/test/mod.rs
@@ -1,11 +1,3 @@
-// Copyright 2016 The RLS Project Developers.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 use crate::loader::SearchDirectory;
 use crate::raw::DefKind;
 use crate::{AnalysisHost, AnalysisLoader};

--- a/rls-analysis/src/test/mod.rs
+++ b/rls-analysis/src/test/mod.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use loader::SearchDirectory;
-use raw::DefKind;
-use {AnalysisHost, AnalysisLoader};
+use crate::loader::SearchDirectory;
+use crate::raw::DefKind;
+use crate::{AnalysisHost, AnalysisLoader};
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};

--- a/rls-analysis/src/util.rs
+++ b/rls-analysis/src/util.rs
@@ -1,11 +1,3 @@
-// Copyright 2016 The RLS Project Developers.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 #[cfg(unix)]
 pub fn get_resident() -> Option<usize> {
     use std::fs::File;

--- a/rls-blacklist/Cargo.toml
+++ b/rls-blacklist/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rls-blacklist"
 version = "0.1.3"
+edition = "2018"
 authors = ["Nick Cameron <ncameron@mozilla.com>"]
 description = "Blacklist of crates for the RLS to skip"
 license = "Apache-2.0/MIT"

--- a/rls-rustc/Cargo.toml
+++ b/rls-rustc/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rls-rustc"
 version = "0.6.0"
+edition = "2018"
 authors = ["Nick Cameron <ncameron@mozilla.com>"]
 description = "A simple shim around rustc to allow using save-analysis with a stable toolchain"
 license = "Apache-2.0/MIT"

--- a/rls-rustc/src/bin/rustc.rs
+++ b/rls-rustc/src/bin/rustc.rs
@@ -1,5 +1,3 @@
-extern crate rls_rustc;
-
 fn main() {
     rls_rustc::run();
 }

--- a/rls-vfs/Cargo.toml
+++ b/rls-vfs/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rls-vfs"
 version = "0.8.0"
+edition = "2018"
 authors = ["Nick Cameron <ncameron@mozilla.com>"]
 description = "Virtual File System for the RLS"
 license = "Apache-2.0/MIT"

--- a/rls-vfs/src/lib.rs
+++ b/rls-vfs/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(rust_2018_idioms)]
+
 extern crate rls_span as span;
 #[macro_use]
 extern crate log;
@@ -150,7 +152,7 @@ impl Into<String> for Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Error::OutOfSync(ref path_buf) => {
                 write!(f, "file {} out of sync with filesystem", path_buf.display())


### PR DESCRIPTION
Converts all the remaining crates to 2018 edition and prunes remaining copyright headers (see https://github.com/rust-lang/rust/pull/57108).