### PR TITLE
Re-export raw::Crate in rls_analysis

### DIFF
--- a/rls-analysis/src/lib.rs
+++ b/rls-analysis/src/lib.rs
@@ -21,7 +21,7 @@ mod util;
 use analysis::Analysis;
 pub use analysis::{Def, Ref};
 pub use loader::{AnalysisLoader, CargoAnalysisLoader, SearchDirectory, Target};
-pub use raw::{name_space_for_def_kind, read_analysis_from_files, CrateId, DefKind};
+pub use raw::{name_space_for_def_kind, read_analysis_from_files, Crate, CrateId, DefKind};
 pub use symbol_query::SymbolQuery;
 
 use std::collections::HashMap;

--- a/rls-analysis/src/lowering.rs
+++ b/rls-analysis/src/lowering.rs
@@ -2,13 +2,10 @@
 //! in-memory representation.
 
 use crate::analysis::{Def, Glob, PerCrateAnalysis, Ref};
-use data;
 use crate::loader::AnalysisLoader;
 use crate::raw::{self, CrateId, DefKind, RelationKind};
 use crate::util;
 use crate::{AResult, AnalysisHost, Id, Span, NULL};
-
-use span;
 
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};

--- a/rls-analysis/src/raw.rs
+++ b/rls-analysis/src/raw.rs
@@ -4,14 +4,15 @@ pub use data::{
     CratePreludeData, Def, DefKind, GlobalCrateId as CrateId, Import, Ref, Relation, RelationKind,
     SigElement, Signature, SpanData,
 };
-use crate::listings::{DirectoryListing, ListingKind};
-use crate::{AnalysisLoader, Blacklist};
 
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::time::{Instant, SystemTime};
+
+use crate::listings::{DirectoryListing, ListingKind};
+use crate::{AnalysisLoader, Blacklist};
 
 #[derive(Debug)]
 pub struct Crate {


### PR DESCRIPTION
Fixes #1491 and continues some cleanup from #1507.