### PR TITLE
Clean up a bit

### DIFF
--- a/rls-vfs/src/lib.rs
+++ b/rls-vfs/src/lib.rs
@@ -50,6 +50,7 @@ pub enum VfsSpan {
     Utf16CodeUnit(SpanData),
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl VfsSpan {
     pub fn from_usv(span: span::Span<span::ZeroIndexed>, len: Option<u64>) -> VfsSpan {
         VfsSpan::UnicodeScalarValue(SpanData { span, len })

--- a/rls/src/actions/mod.rs
+++ b/rls/src/actions/mod.rs
@@ -86,9 +86,9 @@ impl ActionContext {
         let ctx = match *self {
             ActionContext::Uninit(ref uninit) => {
                 let ctx = InitActionContext::new(
-                    uninit.analysis.clone(),
-                    uninit.vfs.clone(),
-                    uninit.config.clone(),
+                    Arc::clone(&uninit.analysis),
+                    Arc::clone(&uninit.vfs),
+                    Arc::clone(&uninit.config),
                     client_capabilities,
                     current_project,
                     uninit.pid,
@@ -189,7 +189,7 @@ impl InitActionContext {
         pid: u32,
         client_supports_cmd_run: bool,
     ) -> InitActionContext {
-        let build_queue = BuildQueue::new(vfs.clone(), config.clone());
+        let build_queue = BuildQueue::new(Arc::clone(&vfs), Arc::clone(&config));
         let analysis_queue = Arc::new(AnalysisQueue::init());
         InitActionContext {
             analysis,
@@ -226,7 +226,7 @@ impl InitActionContext {
                 info!("loading cargo project model");
                 let pm = ProjectModel::load(&self.current_project.join("Cargo.toml"), &self.vfs)?;
                 let pm = Arc::new(pm);
-                *self.project_model.lock().unwrap() = Some(pm.clone());
+                *self.project_model.lock().unwrap() = Some(Arc::clone(&pm));
                 Ok(pm)
             }
         }
@@ -245,7 +245,7 @@ impl InitActionContext {
                 }
             }
         }
-        racer::FileCache::new(RacerVfs(self.vfs.clone()))
+        racer::FileCache::new(RacerVfs(Arc::clone(&self.vfs)))
     }
 
     pub fn racer_session<'c>(&self, cache: &'c racer::FileCache) -> racer::Session<'c> {
@@ -326,15 +326,15 @@ impl InitActionContext {
         let pbh = {
             let config = self.config.lock().unwrap();
             PostBuildHandler {
-                analysis: self.analysis.clone(),
-                analysis_queue: self.analysis_queue.clone(),
-                previous_build_results: self.previous_build_results.clone(),
-                file_to_crates: self.file_to_crates.clone(),
+                analysis: Arc::clone(&self.analysis),
+                analysis_queue: Arc::clone(&self.analysis_queue),
+                previous_build_results: Arc::clone(&self.previous_build_results),
+                file_to_crates: Arc::clone(&self.file_to_crates),
                 project_path: project_path.to_owned(),
                 show_warnings: config.show_warnings,
                 related_information_support: self.client_capabilities.related_information_support,
-                shown_cargo_error: self.shown_cargo_error.clone(),
-                active_build_count: self.active_build_count.clone(),
+                shown_cargo_error: Arc::clone(&self.shown_cargo_error),
+                active_build_count: Arc::clone(&self.active_build_count),
                 crate_blacklist: config.crate_blacklist.as_ref().clone(),
                 notifier: Box::new(BuildDiagnosticsNotifier::new(out.clone())),
                 blocked_threads: vec![],

--- a/rls/src/actions/notifications.rs
+++ b/rls/src/actions/notifications.rs
@@ -5,6 +5,7 @@ use crate::Span;
 use log::{debug, trace, warn};
 use rls_vfs::{Change, VfsSpan};
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use crate::build::*;
 use crate::lsp_data::request::{RangeFormatting, RegisterCapability, UnregisterCapability};
@@ -170,7 +171,7 @@ impl BlockingNotificationAction for DidChangeConfiguration {
 
             if needs_inference {
                 let project_dir = ctx.current_project.clone();
-                let config = ctx.config.clone();
+                let config = Arc::clone(&ctx.config);
                 // Will lock and access Config just outside the current scope
                 thread::spawn(move || {
                     let mut config = config.lock().unwrap();

--- a/rls/src/actions/post_build.rs
+++ b/rls/src/actions/post_build.rs
@@ -293,6 +293,7 @@ impl Drop for AnalysisQueue {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum QueuedJob {
     Job(Job),
     Terminate,

--- a/rls/src/actions/post_build.rs
+++ b/rls/src/actions/post_build.rs
@@ -232,10 +232,10 @@ pub struct AnalysisQueue {
 impl AnalysisQueue {
     // Create a new queue and start the worker thread.
     pub fn init() -> AnalysisQueue {
-        let queue = Arc::new(Mutex::new(Vec::new()));
+        let queue = Arc::default();
         let worker_thread = thread::spawn({
             let queue = Arc::clone(&queue);
-            move || AnalysisQueue::run_worker_thread(queue)
+            || AnalysisQueue::run_worker_thread(queue)
         })
         .thread()
         .clone();

--- a/rls/src/actions/requests.rs
+++ b/rls/src/actions/requests.rs
@@ -183,9 +183,8 @@ impl RequestAction for Definition {
         // Save-analysis thread.
         let file_path = parse_file_path!(&params.text_document.uri, "goto_def")?;
         let span = ctx.convert_pos_to_span(file_path.clone(), params.position);
-        let analysis = ctx.analysis.clone();
 
-        if let Ok(out) = analysis.goto_def(&span) {
+        if let Ok(out) = ctx.analysis.goto_def(&span) {
             let result = vec![ls_util::rls_to_location(&out)];
             trace!("goto_def (compiler): {:?}", result);
             Ok(result)

--- a/rls/src/build/cargo.rs
+++ b/rls/src/build/cargo.rs
@@ -363,9 +363,9 @@ impl Executor for RlsExecutor {
             .as_cargo_mut()
             .expect("build plan should be properly initialized before running Cargo");
 
-        let only_primary = |unit: &Unit<'_>| self.is_primary_package(unit.pkg.package_id());
+        let only_primary = |unit: Unit<'_>| self.is_primary_package(unit.pkg.package_id());
 
-        plan.emplace_dep_with_filter(unit, cx, &only_primary);
+        plan.emplace_dep_with_filter(*unit, cx, &only_primary);
     }
 
     fn force_rebuild(&self, unit: &Unit<'_>) -> bool {

--- a/rls/src/build/cargo.rs
+++ b/rls/src/build/cargo.rs
@@ -59,7 +59,7 @@ pub(super) fn cargo(
         let analysis = Arc::clone(&analysis);
         let input_files = Arc::clone(&input_files);
         let out = Arc::clone(&out);
-        move || {
+        || {
             run_cargo(
                 compilation_cx,
                 package_arg,

--- a/rls/src/build/rustc.rs
+++ b/rls/src/build/rustc.rs
@@ -188,11 +188,10 @@ impl rustc_driver::Callbacks for RlsRustcCalls {
                 RustcEdition::Edition2018 => Edition::Edition2018,
             },
         };
-        let files = fetch_input_files(sess);
 
         let mut input_files = self.input_files.lock().unwrap();
-        for file in &files {
-            input_files.entry(file.to_path_buf()).or_default().insert(krate.clone());
+        for file in fetch_input_files(sess) {
+            input_files.entry(file).or_default().insert(krate.clone());
         }
 
         // Guaranteed to not be dropped yet in the pipeline thanks to the
@@ -285,7 +284,6 @@ fn fetch_input_files(sess: &Session) -> Vec<PathBuf> {
         .filter(|fmap| !fmap.is_imported())
         .map(|fmap| fmap.name.to_string())
         .map(|fmap| src_path(Some(cwd), fmap).unwrap())
-        .map(PathBuf::from)
         .collect()
 }
 

--- a/rls/src/build/rustc.rs
+++ b/rls/src/build/rustc.rs
@@ -85,7 +85,7 @@ pub(crate) fn rustc(
     let restore_env = Environment::push_with_lock(&local_envs, cwd, guard);
 
     let buf = Arc::new(Mutex::new(vec![]));
-    let err_buf = buf.clone();
+    let err_buf = Arc::clone(&buf);
     let args: Vec<_> = if cfg!(feature = "clippy") && clippy_preference != ClippyPreference::Off {
         // Allow feature gating in the same way as `cargo clippy`
         let mut clippy_args = vec!["--cfg".to_owned(), r#"feature="cargo-clippy""#.to_owned()];

--- a/rls/src/cmd.rs
+++ b/rls/src/cmd.rs
@@ -369,7 +369,7 @@ fn init() -> Sender<String> {
         Box::new(ChannelMsgReader::new(receiver)),
         PrintlnOutput,
     );
-    thread::spawn(move || LsService::run(service));
+    thread::spawn(|| LsService::run(service));
 
     sender
         .send(

--- a/rls/src/lib.rs
+++ b/rls/src/lib.rs
@@ -6,7 +6,8 @@
 //! code completion, and enables renaming and refactorings.
 
 #![feature(rustc_private, drain_filter)]
-#![warn(clippy::all, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
+#![warn(clippy::all, clippy::clone_on_ref_ptr)]
 #![allow(clippy::cognitive_complexity, clippy::too_many_arguments, clippy::redundant_closure)]
 
 #[macro_use]


### PR DESCRIPTION
* Fixes remaining Clippy lints
* Prefer a named `UnitKey` type to leverage `From` impl and simplify some destructuring
* Prefer `Arc::clone` over `.clone()` (we have a very `Arc`-heavy code, it helps to spot "cheap" clones)
* Prefer `{ let a = Arc::clone(&a);... <closure> }` syntax to copy these into closure (to work around noisy `_clone` suffixed vars)