### PR TITLE
Collect file -> edition mapping after AST expansion

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 - Support both owned and borrowed blacklisted crate names in `rls-analysis`
 - Publicly re-export `rls_analysis::raw::Crate`
 ### Changed
+- Formatting project files now only needs project to parse and expand macros (and not type-check)
 - Converted remaining crates `rls-*` to 2018 edition
 ### Removed
 - Removed `use_crate_blacklist` setting in favour of `crate_blacklist`


### PR DESCRIPTION
Reason for that being so that non-syntax errors should still allow us to reason about which file belongs to a given crate, which specifically allows us to run a formatter even if the code contains type errors or similar.

Should make the formatter Just Work^TM in the cases where it could've technically worked before (e.g. no syntax errors).

Requires https://github.com/rust-lang/rust/pull/62679