### PR TITLE
Ignore spurious client_deglob test

### DIFF
--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1126,6 +1126,7 @@ fn client_find_definitions() {
 }
 
 #[test]
+#[ignore] // Spurious in Rust CI, https://github.com/rust-lang/rust/pull/62805
 fn client_deglob() {
     let p = ProjectBuilder::try_from_fixture(fixtures_dir().join("deglob")).unwrap().build();
     let root_path = p.root();


### PR DESCRIPTION
I believe this is the only remaining spurious tests that causes false positives in Rust CI. It'd be good to fix the underlying issue but this has prevented to land a broken toolstate fix for some time now so let's ignore it for now.