### PR TITLE
Don't forcibly set CARGO_MANIFEST_DIR as a workaround for Clippy

### DIFF
--- a/rls/src/build/rustc.rs
+++ b/rls/src/build/rustc.rs
@@ -78,8 +78,6 @@ pub(crate) fn rustc(
 
         config.clippy_preference
     };
-    // Required for Clippy not to crash when running outside Cargo?
-    local_envs.entry("CARGO_MANIFEST_DIR".into()).or_insert_with(|| Some(build_dir.into()));
 
     let (guard, _) = env_lock.lock();
     let restore_env = Environment::push_with_lock(&local_envs, cwd, guard);


### PR DESCRIPTION
Enabled by https://github.com/rust-lang/rust-clippy/pull/3665.

When using Cargo build plan we always have `CARGO_MANIFEST_DIR` set so I believe this was done to support external build plan work.

r? @jsgf