### PR TITLE
Fix rustfmt during builds by reading edition from manifest

### DIFF
--- a/rls/src/actions/mod.rs
+++ b/rls/src/actions/mod.rs
@@ -292,7 +292,7 @@ impl InitActionContext {
             (ret @ Some(_), None) => ret,
             (Some(_), Some(_)) => None,
             _ => {
-                // fall back on checking the root manifest for edition
+                // fall back on checking the root manifest for package edition
                 let manifest_path =
                     cargo::util::important_paths::find_root_manifest_for_wd(&file).ok()?;
                 edition_from_manifest(manifest_path)
@@ -435,7 +435,7 @@ impl InitActionContext {
     }
 }
 
-/// Read edition from the manifest
+/// Read package edition from the Cargo manifest
 fn edition_from_manifest<P: AsRef<Path>>(manifest_path: P) -> Option<Edition> {
     #[derive(Debug, serde::Deserialize)]
     struct Manifest {

--- a/rls/src/actions/mod.rs
+++ b/rls/src/actions/mod.rs
@@ -23,12 +23,12 @@ use crate::project_model::{ProjectModel, RacerFallbackModel, RacerProjectModel};
 use crate::server::Output;
 
 use std::collections::{HashMap, HashSet};
+use std::convert::TryFrom;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::convert::TryFrom;
 
 // TODO: Support non-`file` URI schemes in VFS. We're currently ignoring them because
 // we don't want to crash the RLS in case a client opens a file under different URI scheme
@@ -700,10 +700,13 @@ mod test {
         let manifest_path = {
             let path = dir.path().join("Cargo.toml");
             let mut m = File::create(&path)?;
-            writeln!(m, "[package]\n\
-                         name = \"foo\"\n\
-                         version = \"1.0.0\"\n\
-                         edition = \"2018\"")?;
+            writeln!(
+                m,
+                "[package]\n\
+                 name = \"foo\"\n\
+                 version = \"1.0.0\"\n\
+                 edition = \"2018\""
+            )?;
             path
         };
 

--- a/rls/src/build/plan.rs
+++ b/rls/src/build/plan.rs
@@ -242,3 +242,15 @@ impl Default for Edition {
         Edition::Edition2015
     }
 }
+
+impl std::convert::TryFrom<&str> for Edition {
+    type Error = &'static str;
+
+    fn try_from(val: &str) -> Result<Self, Self::Error> {
+        Ok(match val {
+            "2015" => Edition::Edition2015,
+            "2018" => Edition::Edition2018,
+            _ => return Err("unknown"),
+        })
+    }
+}


### PR DESCRIPTION
Not being able to run rustfmt when code is building has been getting on my nerves a bit.

This pr adds a fallback to cover cases where `files_to_crates` is empty causing format requests to fail as we can't currently determine the edition to use. In these cases the manifest is read directly to determine edition.

Fixes #1148