### PR TITLE
rls-analysis: add a feature to return all identifiers in a span.

### DIFF
--- a/rls-analysis/Cargo.toml
+++ b/rls-analysis/Cargo.toml
@@ -11,10 +11,15 @@ exclude = [
     "test_data/*",
 ]
 
+[features]
+default = []
+idents = ["rls-span/nightly"]
+derive = ["rls-data/derive", "rls-span/derive"]
+
 [dependencies]
 log = "0.4"
 rls-data = "= 0.19"
-rls-span = "0.5"
+rls-span = "0.5.2"
 derive-new = "0.5"
 fst = { version = "0.3", default-features = false }
 itertools = "0.8"
@@ -25,7 +30,3 @@ serde_json = "1.0"
 [dev-dependencies]
 lazy_static = "1"
 env_logger = "0.5"
-
-[features]
-default = []
-derive = ["rls-data/derive", "rls-span/derive"]

--- a/rls-analysis/src/analysis.rs
+++ b/rls-analysis/src/analysis.rs
@@ -1,16 +1,16 @@
 use fst;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::iter;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use crate::raw::{CrateId, DefKind};
 use crate::{Id, Span, SymbolQuery};
+use span::{Column, Row, ZeroIndexed};
 
 /// This is the main database that contains all the collected symbol information,
 /// such as definitions, their mapping between spans, hierarchy and so on,
 /// organized in a per-crate fashion.
-#[derive(Debug)]
 pub(crate) struct Analysis {
     /// Contains lowered data with global inter-crate `Id`s per each crate.
     pub per_crate: HashMap<CrateId, PerCrateAnalysis>,
@@ -31,7 +31,6 @@ pub(crate) struct Analysis {
     pub src_url_base: String,
 }
 
-#[derive(Debug)]
 pub struct PerCrateAnalysis {
     // Map span to id of def (either because it is the span of the def, or of
     // the def for the ref).
@@ -49,6 +48,7 @@ pub struct PerCrateAnalysis {
     pub ref_spans: HashMap<Id, Vec<Span>>,
     pub globs: HashMap<Span, Glob>,
     pub impls: HashMap<Id, Vec<Span>>,
+    pub idents: Idents,
 
     pub root_id: Option<Id>,
     pub timestamp: SystemTime,
@@ -103,6 +103,34 @@ pub struct Def {
     // pub sig: Option<Signature>,
 }
 
+pub type Idents = HashMap<PathBuf, IdentsByLine>;
+pub type IdentsByLine = BTreeMap<Row<ZeroIndexed>, IdentsByColumn>;
+pub type IdentsByColumn = BTreeMap<Column<ZeroIndexed>, IdentBound>;
+
+#[derive(new, Clone, Debug)]
+pub struct IdentBound {
+    pub column_end: Column<ZeroIndexed>,
+    pub id: Id,
+    pub kind: IdentKind,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum IdentKind {
+    Def,
+    Ref,
+}
+
+/// An identifier (either a reference or definition).
+///
+/// This struct represents the syntactic name, use the `id` to look up semantic
+/// information.
+#[derive(new, Clone, Debug)]
+pub struct Ident {
+    pub span: Span,
+    pub id: Id,
+    pub kind: IdentKind,
+}
+
 #[derive(Debug, Clone)]
 pub struct Signature {
     pub span: Span,
@@ -139,6 +167,7 @@ impl PerCrateAnalysis {
             ref_spans: HashMap::new(),
             globs: HashMap::new(),
             impls: HashMap::new(),
+            idents: Idents::new(),
             root_id: None,
             timestamp,
             path,
@@ -154,6 +183,48 @@ impl PerCrateAnalysis {
             Some(existing) => span == &existing.span,
             None => false,
         }
+    }
+
+    // Returns all identifiers which overlap with `span`. There is no guarantee about
+    // the ordering of identifiers in the result, but they will probably be roughly
+    // in order of appearance.
+    #[cfg(feature = "idents")]
+    fn idents(&self, span: &Span) -> Vec<Ident> {
+        self.idents
+            .get(&span.file)
+            .map(|by_line| {
+                (span.range.row_start..=span.range.row_end)
+                    .flat_map(|line| {
+                        let vec = by_line
+                            .get(&line)
+                            .iter()
+                            .flat_map(|by_col| {
+                                by_col.into_iter().filter_map(|(col_start, id)| {
+                                    if col_start <= &span.range.col_end
+                                        && id.column_end >= span.range.col_start
+                                    {
+                                        Some(Ident::new(
+                                            Span::new(
+                                                line,
+                                                line,
+                                                *col_start,
+                                                id.column_end,
+                                                span.file.clone(),
+                                            ),
+                                            id.id,
+                                            id.kind,
+                                        ))
+                                    } else {
+                                        None
+                                    }
+                                })
+                            })
+                            .collect::<Vec<Ident>>();
+                        vec.into_iter()
+                    })
+                    .collect::<Vec<Ident>>()
+            })
+            .unwrap_or_else(|| Vec::new())
     }
 }
 
@@ -300,6 +371,19 @@ impl Analysis {
         F: Fn(&Vec<Id>) -> T,
     {
         self.for_each_crate(|c| c.defs_per_file.get(file).map(&f))
+    }
+
+    #[cfg(feature = "idents")]
+    pub fn idents(&self, span: &Span) -> Vec<Ident> {
+        self.for_each_crate(|c| {
+            let result = c.idents(span);
+            if result.is_empty() {
+                None
+            } else {
+                Some(result)
+            }
+        })
+        .unwrap_or_else(Vec::new)
     }
 
     pub fn query_defs(&self, query: SymbolQuery) -> Vec<Def> {

--- a/rls-analysis/src/lib.rs
+++ b/rls-analysis/src/lib.rs
@@ -19,7 +19,7 @@ mod test;
 mod util;
 
 use analysis::Analysis;
-pub use analysis::{Def, Ref};
+pub use analysis::{Def, Ident, IdentKind, Ref};
 pub use loader::{AnalysisLoader, CargoAnalysisLoader, SearchDirectory, Target};
 pub use raw::{name_space_for_def_kind, read_analysis_from_files, Crate, CrateId, DefKind};
 pub use symbol_query::SymbolQuery;
@@ -31,7 +31,6 @@ use std::sync::Mutex;
 use std::time::{Instant, SystemTime};
 use std::u64;
 
-#[derive(Debug)]
 pub struct AnalysisHost<L: AnalysisLoader = CargoAnalysisLoader> {
     analysis: Mutex<Option<Analysis>>,
     master_crate_map: Mutex<HashMap<CrateId, u32>>,
@@ -425,6 +424,12 @@ impl<L: AnalysisLoader> AnalysisHost<L> {
     /// Search for a symbol name, returning a list of def_ids for that name.
     pub fn search_for_id(&self, name: &str) -> AResult<Vec<Id>> {
         self.with_analysis(|a| Some(a.with_def_names(name, Clone::clone)))
+    }
+
+    /// Returns all identifiers which overlap the given span.
+    #[cfg(feature = "idents")]
+    pub fn idents(&self, span: &Span) -> AResult<Vec<Ident>> {
+        self.with_analysis(|a| Some(a.idents(span)))
     }
 
     pub fn symbols(&self, file_name: &Path) -> AResult<Vec<SymbolResult>> {

--- a/rls-analysis/src/lowering.rs
+++ b/rls-analysis/src/lowering.rs
@@ -244,12 +244,12 @@ impl<'a> CrateReader<'a> {
                     ve.insert(Ref::Id(def_id));
                 }
             }
-            analysis.ref_spans.entry(def_id).or_insert_with(Vec::new).push(span.clone());
 
             #[cfg(feature = "idents")]
             {
                 Self::record_ident(analysis, &span, def_id, IdentKind::Ref);
             }
+            analysis.ref_spans.entry(def_id).or_insert_with(Vec::new).push(span);
         }
     }
 

--- a/rls-analysis/src/lowering.rs
+++ b/rls-analysis/src/lowering.rs
@@ -2,6 +2,8 @@
 //! in-memory representation.
 
 use crate::analysis::{Def, Glob, PerCrateAnalysis, Ref};
+#[cfg(feature = "idents")]
+use crate::analysis::{IdentBound, IdentKind, IdentsByColumn, IdentsByLine};
 use crate::loader::AnalysisLoader;
 use crate::raw::{self, CrateId, DefKind, RelationKind};
 use crate::util;
@@ -186,7 +188,7 @@ impl<'a> CrateReader<'a> {
                 .unwrap()
                 .crate_names
                 .entry(krate.id.name.clone())
-                .or_insert_with(|| vec![])
+                .or_insert_with(Vec::new)
                 .push(krate.id.clone());
         }
 
@@ -242,8 +244,28 @@ impl<'a> CrateReader<'a> {
                     ve.insert(Ref::Id(def_id));
                 }
             }
-            analysis.ref_spans.entry(def_id).or_insert_with(|| vec![]).push(span);
+            analysis.ref_spans.entry(def_id).or_insert_with(Vec::new).push(span.clone());
+
+            #[cfg(feature = "idents")]
+            {
+                Self::record_ident(analysis, &span, def_id, IdentKind::Ref);
+            }
         }
+    }
+
+    #[cfg(feature = "idents")]
+    fn record_ident(analysis: &mut PerCrateAnalysis, span: &Span, id: Id, kind: IdentKind) {
+        let row_start = span.range.row_start;
+        let col_start = span.range.col_start;
+        let col_end = span.range.col_end;
+        analysis
+            .idents
+            .entry(span.file.clone())
+            .or_insert_with(IdentsByLine::new)
+            .entry(row_start)
+            .or_insert_with(IdentsByColumn::new)
+            .entry(col_start)
+            .or_insert_with(|| IdentBound::new(col_end, id, kind));
     }
 
     // We are sometimes asked to analyze the same crate twice. This can happen due to duplicate data,
@@ -314,14 +336,14 @@ impl<'a> CrateReader<'a> {
             let id = self.id_from_compiler_id(d.id);
             if id != NULL && !analysis.defs.contains_key(&id) {
                 let file_name = span.file.clone();
-                analysis.defs_per_file.entry(file_name).or_insert_with(|| vec![]).push(id);
+                analysis.defs_per_file.entry(file_name).or_insert_with(Vec::new).push(id);
                 let decl_id = match d.decl_id {
                     Some(ref decl_id) => {
                         let def_id = self.id_from_compiler_id(*decl_id);
                         analysis
                             .ref_spans
                             .entry(def_id)
-                            .or_insert_with(|| vec![])
+                            .or_insert_with(Vec::new)
                             .push(span.clone());
                         Ref::Id(def_id)
                     }
@@ -336,7 +358,7 @@ impl<'a> CrateReader<'a> {
                     }
                 }
 
-                analysis.def_names.entry(d.name.clone()).or_insert_with(|| vec![]).push(id);
+                analysis.def_names.entry(d.name.clone()).or_insert_with(Vec::new).push(id);
 
                 // NOTE not every Def will have a name, e.g. test_data/hello/src/main is analyzed with an implicit module
                 // that's fine, but no need to index in def_trie
@@ -353,6 +375,11 @@ impl<'a> CrateReader<'a> {
                     let children_for_id = analysis.children.entry(id).or_insert_with(HashSet::new);
                     children_for_id
                         .extend(d.children.iter().map(|id| self.id_from_compiler_id(*id)));
+                }
+
+                #[cfg(feature = "idents")]
+                {
+                    Self::record_ident(analysis, &span, id, IdentKind::Def);
                 }
 
                 let def = Def {
@@ -431,13 +458,13 @@ impl<'a> CrateReader<'a> {
             if self_id != NULL {
                 if let Some(self_id) = abs_ref_id(self_id, analysis, project_analysis) {
                     trace!("record impl for self type {:?} {}", span, self_id);
-                    analysis.impls.entry(self_id).or_insert_with(|| vec![]).push(span.clone());
+                    analysis.impls.entry(self_id).or_insert_with(Vec::new).push(span.clone());
                 }
             }
             if trait_id != NULL {
                 if let Some(trait_id) = abs_ref_id(trait_id, analysis, project_analysis) {
                     trace!("record impl for trait {:?} {}", span, trait_id);
-                    analysis.impls.entry(trait_id).or_insert_with(|| vec![]).push(span);
+                    analysis.impls.entry(trait_id).or_insert_with(Vec::new).push(span);
                 }
             }
         }


### PR DESCRIPTION
This is useful for getting all symbols in a file, for highlighting identifiers on a line or highlighted region, etc. I think it could get a little expensive, so I made it opt-in for now.

r? @Xanewok 