### PR TITLE
Warn against deprecated config entries

### DIFF
--- a/rls/src/actions/notifications.rs
+++ b/rls/src/actions/notifications.rs
@@ -140,9 +140,15 @@ impl BlockingNotificationAction for DidChangeConfiguration {
         use std::collections::HashMap;
         let mut dups = HashMap::new();
         let mut unknowns = vec![];
-        let settings =
-            ChangeConfigSettings::try_deserialize(&params.settings, &mut dups, &mut unknowns);
+        let mut deprecated = vec![];
+        let settings = ChangeConfigSettings::try_deserialize(
+            &params.settings,
+            &mut dups,
+            &mut unknowns,
+            &mut deprecated,
+        );
         crate::server::maybe_notify_unknown_configs(&out, &unknowns);
+        crate::server::maybe_notify_deprecated_configs(&out, &deprecated);
         crate::server::maybe_notify_duplicated_configs(&out, &dups);
 
         let new_config = match settings {

--- a/rls/src/lsp_data.rs
+++ b/rls/src/lsp_data.rs
@@ -326,8 +326,8 @@ impl ClientCapabilities {
             .and_then(|doc| doc.completion.as_ref())
             .and_then(|comp| comp.completion_item.as_ref())
             .and_then(|item| item.snippet_support.as_ref())
-            .unwrap_or(&false)
-            .to_owned();
+            .copied()
+            .unwrap_or(false);
 
         let related_information_support = params
             .capabilities
@@ -335,8 +335,8 @@ impl ClientCapabilities {
             .as_ref()
             .and_then(|doc| doc.publish_diagnostics.as_ref())
             .and_then(|diag| diag.related_information.as_ref())
-            .unwrap_or(&false)
-            .to_owned();
+            .copied()
+            .unwrap_or(false);
 
         ClientCapabilities { code_completion_has_snippet_support, related_information_support }
     }

--- a/rls/src/server/mod.rs
+++ b/rls/src/server/mod.rs
@@ -3,7 +3,7 @@
 //! requests).
 
 use crate::actions::{notifications, requests, ActionContext};
-use crate::config::Config;
+use crate::config::{Config, DEPRECATED_OPTIONS};
 use crate::lsp_data;
 use crate::lsp_data::{
     InitializationOptions, LSPNotification, LSPRequest, MessageType, ShowMessageParams,
@@ -94,6 +94,24 @@ pub(crate) fn maybe_notify_unknown_configs<O: Output>(out: &O, unknowns: &[Strin
     }));
 }
 
+/// For each deprecated configuration key an appropriate warning is emitted via
+/// LSP, along with a deprecation notice (if there is one).
+pub(crate) fn maybe_notify_deprecated_configs<O: Output>(out: &O, keys: &[String]) {
+    for key in keys {
+        let notice = DEPRECATED_OPTIONS.get(key.as_str()).and_then(|x| *x);
+        let message = format!(
+            "RLS configuration option `{}` is deprecated{}",
+            key,
+            notice.map(|notice| format!(": {}", notice)).unwrap_or_default()
+        );
+
+        out.notify(Notification::<ShowMessage>::new(ShowMessageParams {
+            typ: MessageType::Warning,
+            message,
+        }));
+    }
+}
+
 pub(crate) fn maybe_notify_duplicated_configs<O: Output>(
     out: &O,
     dups: &std::collections::HashMap<String, Vec<String>>,
@@ -129,11 +147,18 @@ impl BlockingRequestAction for InitializeRequest {
     ) -> Result<NoResponse, ResponseError> {
         let mut dups = std::collections::HashMap::new();
         let mut unknowns = Vec::new();
+        let mut deprecated = Vec::new();
         let init_options = params
             .initialization_options
             .take()
             .and_then(|opt| {
-                InitializationOptions::try_deserialize(opt, &mut dups, &mut unknowns).ok()
+                InitializationOptions::try_deserialize(
+                    opt,
+                    &mut dups,
+                    &mut unknowns,
+                    &mut deprecated,
+                )
+                .ok()
             })
             .unwrap_or_default();
 
@@ -148,6 +173,7 @@ impl BlockingRequestAction for InitializeRequest {
         }
 
         maybe_notify_unknown_configs(&out, &unknowns);
+        maybe_notify_deprecated_configs(&out, &deprecated);
         maybe_notify_duplicated_configs(&out, &dups);
 
         let result = InitializeResult { capabilities: server_caps(ctx) };

--- a/rls/src/server/mod.rs
+++ b/rls/src/server/mod.rs
@@ -133,7 +133,7 @@ impl BlockingRequestAction for InitializeRequest {
             .initialization_options
             .take()
             .and_then(|opt| {
-                InitializationOptions::try_deserialize(&opt, &mut dups, &mut unknowns).ok()
+                InitializationOptions::try_deserialize(opt, &mut dups, &mut unknowns).ok()
             })
             .unwrap_or_default();
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1272,6 +1272,11 @@ fn is_notification_for_unknown_config(msg: &serde_json::Value) -> bool {
         && msg["params"]["message"].as_str().unwrap().contains("Unknown")
 }
 
+fn is_notification_for_deprecated_config(msg: &serde_json::Value) -> bool {
+    msg["method"] == ShowMessage::METHOD
+        && msg["params"]["message"].as_str().unwrap().contains("is deprecated")
+}
+
 fn is_notification_for_duplicated_config(msg: &serde_json::Value) -> bool {
     msg["method"] == ShowMessage::METHOD
         && msg["params"]["message"].as_str().unwrap().contains("Duplicate")
@@ -1305,7 +1310,9 @@ fn client_init_duplicated_and_unknown_settings() {
                 "dup_val": false,
                 "dup_licated": "dup_lacated",
                 "DupLicated": "DupLicated",
-                "dup-licated": "dup-licated"
+                "dup-licated": "dup-licated",
+                // Deprecated
+                "use_crate_blacklist": true
             }
         }
     });
@@ -1313,6 +1320,10 @@ fn client_init_duplicated_and_unknown_settings() {
     rls.request::<Initialize>(0, initialize_params_with_opts(root_path, opts));
 
     assert!(rls.messages().iter().any(is_notification_for_unknown_config));
+    assert!(
+        rls.messages().iter().any(is_notification_for_deprecated_config),
+        "`use_crate_blacklist` should be marked as deprecated"
+    );
     assert!(rls.messages().iter().any(is_notification_for_duplicated_config));
 }
 


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rls-vscode/pull/643.

Brings back removed option from #1509 but only not to trigger the unknown option warning.