### PR TITLE
Fix RLS compile error for rust-lang/rust#64604 (Update clippy)

### DIFF
--- a/rls-rustc/src/clippy.rs
+++ b/rls-rustc/src/clippy.rs
@@ -49,7 +49,7 @@ pub fn adjust_args(args: Vec<String>, preference: ClippyPreference) -> Vec<Strin
 
 #[cfg(feature = "clippy")]
 pub fn after_parse_callback(compiler: &rustc_interface::interface::Compiler) {
-    use self::rustc_driver::plugin::registry::Registry;
+    use rustc_driver::plugin::registry::Registry;
 
     let sess = compiler.session();
     let mut registry = Registry::new(


### PR DESCRIPTION
This PR remove the incorrect `self::` import prefix on codepath guarded by `#[cfg(feature = "clippy")]`.
When clippy compiles, the `clippy` feature is enabled and trigger [this compiler error](https://github.com/rust-lang/rust/pull/64604#issuecomment-533349741).