### PR TITLE
Update Clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   # Required for Racer autoconfiguration
   - rustup component add rust-src
   - rustup component add rust-analysis
+  - rustup component add rustc-dev
 matrix:
   fast_finish: true
   include:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,9 +262,9 @@ dependencies = [
 [[package]]
 name = "clippy_lints"
 version = "0.0.212"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=68ff8b19bc6705724d1e77a8dc17ffb8dfbbe26b#68ff8b19bc6705724d1e77a8dc17ffb8dfbbe26b"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=66df92aeba64547f3e9600635a30df34b12a11d8#66df92aeba64547f3e9600635a30df34b12a11d8"
 dependencies = [
- "cargo_metadata 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "if_chain 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1597,7 +1608,7 @@ version = "1.39.0"
 dependencies = [
  "cargo 0.41.0 (git+https://github.com/rust-lang/cargo?rev=8b0561d68f12eeb1d72e07ceef464ebf6032a1bc)",
  "cargo_metadata 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy_lints 0.0.212 (git+https://github.com/rust-lang/rust-clippy?rev=68ff8b19bc6705724d1e77a8dc17ffb8dfbbe26b)",
+ "clippy_lints 0.0.212 (git+https://github.com/rust-lang/rust-clippy?rev=66df92aeba64547f3e9600635a30df34b12a11d8)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1680,7 +1691,7 @@ dependencies = [
 name = "rls-rustc"
 version = "0.6.0"
 dependencies = [
- "clippy_lints 0.0.212 (git+https://github.com/rust-lang/rust-clippy?rev=68ff8b19bc6705724d1e77a8dc17ffb8dfbbe26b)",
+ "clippy_lints 0.0.212 (git+https://github.com/rust-lang/rust-clippy?rev=66df92aeba64547f3e9600635a30df34b12a11d8)",
  "env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2666,10 +2677,11 @@ dependencies = [
 "checksum cargo 0.41.0 (git+https://github.com/rust-lang/cargo?rev=8b0561d68f12eeb1d72e07ceef464ebf6032a1bc)" = "<none>"
 "checksum cargo-platform 0.1.0 (git+https://github.com/rust-lang/cargo?rev=8b0561d68f12eeb1d72e07ceef464ebf6032a1bc)" = "<none>"
 "checksum cargo_metadata 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "700b3731fd7d357223d0000f4dbf1808401b694609035c3c411fbc0cd375c426"
+"checksum cargo_metadata 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8d2d1617e838936c0d2323a65cc151e03ae19a7678dd24f72bccf27119b90a5d"
 "checksum cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "b548a4ee81fccb95919d4e22cfea83c7693ebfd78f0495493178db20b3139da7"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
-"checksum clippy_lints 0.0.212 (git+https://github.com/rust-lang/rust-clippy?rev=68ff8b19bc6705724d1e77a8dc17ffb8dfbbe26b)" = "<none>"
+"checksum clippy_lints 0.0.212 (git+https://github.com/rust-lang/rust-clippy?rev=66df92aeba64547f3e9600635a30df34b12a11d8)" = "<none>"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum commoncrypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
 "checksum commoncrypto-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rls-ipc = { version = "0.1.0", path = "rls-ipc", optional = true }
 
 cargo = { git = "https://github.com/rust-lang/cargo", rev = "8b0561d68f12eeb1d72e07ceef464ebf6032a1bc" }
 cargo_metadata = "0.8"
-clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "68ff8b19bc6705724d1e77a8dc17ffb8dfbbe26b", optional = true }
+clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "66df92aeba64547f3e9600635a30df34b12a11d8", optional = true }
 env_logger = "0.7"
 failure = "0.1.1"
 futures = { version = "0.1", optional = true }

--- a/rls-rustc/Cargo.toml
+++ b/rls-rustc/Cargo.toml
@@ -13,7 +13,7 @@ env_logger = "0.7"
 log = "0.4"
 failure = "0.1"
 rand = "0.7"
-clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "68ff8b19bc6705724d1e77a8dc17ffb8dfbbe26b", optional = true }
+clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "66df92aeba64547f3e9600635a30df34b12a11d8", optional = true }
 tokio = { version = "0.1", optional = true }
 futures = { version = "0.1", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }

--- a/rls-rustc/src/clippy.rs
+++ b/rls-rustc/src/clippy.rs
@@ -48,43 +48,18 @@ pub fn adjust_args(args: Vec<String>, preference: ClippyPreference) -> Vec<Strin
 }
 
 #[cfg(feature = "clippy")]
-pub fn after_parse_callback(compiler: &rustc_interface::interface::Compiler) {
-    use rustc_driver::plugin::registry::Registry;
+pub fn config(config: &mut rustc_interface::interface::Config) {
+    let previous = config.register_lints.take();
+    config.register_lints = Some(Box::new(move |sess, mut lint_store| {
+        // technically we're ~guaranteed that this is none but might as well call anything that
+        // is there already. Certainly it can't hurt.
+        if let Some(previous) = &previous {
+            (previous)(sess, lint_store);
+        }
 
-    let sess = compiler.session();
-    let mut registry = Registry::new(
-        sess,
-        compiler
-            .parse()
-            .expect(
-                "at this compilation stage \
-                 the crate must be parsed",
-            )
-            .peek()
-            .span,
-    );
-    registry.args_hidden = Some(Vec::new());
-
-    let conf = clippy_lints::read_conf(&registry);
-    clippy_lints::register_plugins(&mut registry, &conf);
-
-    let Registry {
-        early_lint_passes, late_lint_passes, lint_groups, llvm_passes, attributes, ..
-    } = registry;
-    let mut ls = sess.lint_store.borrow_mut();
-    for pass in early_lint_passes {
-        ls.register_early_pass(Some(sess), true, false, pass);
-    }
-    for pass in late_lint_passes {
-        ls.register_late_pass(Some(sess), true, false, false, pass);
-    }
-
-    for (name, (to, deprecated_name)) in lint_groups {
-        ls.register_group(Some(sess), true, name, deprecated_name, to);
-    }
-    clippy_lints::register_pre_expansion_lints(sess, &mut ls, &conf);
-    clippy_lints::register_renamed(&mut ls);
-
-    sess.plugin_llvm_passes.borrow_mut().extend(llvm_passes);
-    sess.plugin_attributes.borrow_mut().extend(attributes);
+        let conf = clippy_lints::read_conf(&[], &sess);
+        clippy_lints::register_plugins(&mut lint_store, &sess, &conf);
+        clippy_lints::register_pre_expansion_lints(&mut lint_store, &conf);
+        clippy_lints::register_renamed(&mut lint_store);
+    }));
 }

--- a/rls-rustc/src/lib.rs
+++ b/rls-rustc/src/lib.rs
@@ -90,18 +90,14 @@ impl Callbacks for ShimCalls {
     fn config(&mut self, config: &mut interface::Config) {
         config.opts.debugging_opts.continue_parse_after_error = true;
         config.opts.debugging_opts.save_analysis = true;
-    }
 
-    #[cfg(feature = "clippy")]
-    fn after_parsing(&mut self, compiler: &interface::Compiler) -> Compilation {
+        #[cfg(feature = "clippy")]
         match self.clippy_preference {
             Some(preference) if preference != clippy::ClippyPreference::Off => {
-                clippy::after_parse_callback(compiler);
+                clippy::config(config);
             }
             _ => {}
         }
-
-        Compilation::Continue
     }
 
     #[cfg(feature = "ipc")]

--- a/rls/src/build/rustc.rs
+++ b/rls/src/build/rustc.rs
@@ -236,17 +236,13 @@ impl rustc_driver::Callbacks for RlsRustcCalls {
         // still need in the `after_analysis` callback in order to process and
         // pass the computed analysis in-memory.
         config.opts.debugging_opts.save_analysis = true;
-    }
 
-    fn after_parsing(&mut self, _compiler: &interface::Compiler) -> Compilation {
         #[cfg(feature = "clippy")]
         {
             if self.clippy_preference != ClippyPreference::Off {
-                clippy_after_parse_callback(_compiler);
+                clippy_config(config);
             }
         }
-
-        Compilation::Continue
     }
 
     fn after_expansion(&mut self, compiler: &interface::Compiler) -> Compilation {
@@ -325,45 +321,20 @@ impl rustc_driver::Callbacks for RlsRustcCalls {
 }
 
 #[cfg(feature = "clippy")]
-fn clippy_after_parse_callback(compiler: &interface::Compiler) {
-    use self::rustc_driver::plugin::registry::Registry;
+fn clippy_config(config: &mut interface::Config) {
+    let previous = config.register_lints.take();
+    config.register_lints = Some(Box::new(move |sess, mut lint_store| {
+        // technically we're ~guaranteed that this is none but might as well call anything that
+        // is there already. Certainly it can't hurt.
+        if let Some(previous) = &previous {
+            (previous)(sess, lint_store);
+        }
 
-    let sess = compiler.session();
-    let mut registry = Registry::new(
-        sess,
-        compiler
-            .parse()
-            .expect(
-                "at this compilation stage \
-                 the crate must be parsed",
-            )
-            .peek()
-            .span,
-    );
-    registry.args_hidden = Some(Vec::new());
-
-    let conf = clippy_lints::read_conf(&registry);
-    clippy_lints::register_plugins(&mut registry, &conf);
-
-    let Registry {
-        early_lint_passes, late_lint_passes, lint_groups, llvm_passes, attributes, ..
-    } = registry;
-    let mut ls = sess.lint_store.borrow_mut();
-    for pass in early_lint_passes {
-        ls.register_early_pass(Some(sess), true, false, pass);
-    }
-    for pass in late_lint_passes {
-        ls.register_late_pass(Some(sess), true, false, false, pass);
-    }
-
-    for (name, (to, deprecated_name)) in lint_groups {
-        ls.register_group(Some(sess), true, name, deprecated_name, to);
-    }
-    clippy_lints::register_pre_expansion_lints(sess, &mut ls, &conf);
-    clippy_lints::register_renamed(&mut ls);
-
-    sess.plugin_llvm_passes.borrow_mut().extend(llvm_passes);
-    sess.plugin_attributes.borrow_mut().extend(attributes);
+        let conf = clippy_lints::read_conf(&[], &sess);
+        clippy_lints::register_plugins(&mut lint_store, &sess, &conf);
+        clippy_lints::register_pre_expansion_lints(&mut lint_store, &conf);
+        clippy_lints::register_renamed(&mut lint_store);
+    }));
 }
 
 fn fetch_input_files(sess: &Session) -> Vec<PathBuf> {


### PR DESCRIPTION
This updates Clippy to the version of https://github.com/rust-lang/rust/pull/65852. This is probably blocked until the rustc clippyup hits nightly (?).

The changes to the `after_parse_callback` functions are according to: https://github.com/rust-lang/rust-clippy/commit/7e77f3c29f9221ccd785aa99ffd8b6180d4c063d