### PR TITLE
Pass file directory as cwd for Run test of CodeLens

### DIFF
--- a/rls/src/actions/run.rs
+++ b/rls/src/actions/run.rs
@@ -67,6 +67,7 @@ pub fn collect_run_actions(ctx: &InitActionContext, file: &Path) -> Vec<RunActio
                     test_name.to_string(),
                 ],
                 env: iter::once(("RUST_BACKTRACE".to_string(), "short".to_string())).collect(),
+                cwd: file.parent().and_then(|dir| dir.to_str()).map(String::from),
             },
         };
         ret.push(run_action);
@@ -85,6 +86,7 @@ pub struct Cmd {
     pub binary: String,
     pub args: Vec<String>,
     pub env: HashMap<String, String>,
+    pub cwd: Option<String>,
 }
 
 pub struct LineIndex {


### PR DESCRIPTION
In the previous implementation:

When there is a Cargo Workspace including several member packages, clicking CodeLens Run test button in source code files of a member package triggers shell execution `cargo test -- --no-capture ...` without specifying a current working directory.It appears that the default cwd is the Workspace / top-level package root (as expected).

Consequently, nothing is really tested as `cargo test` does not cover member packages unless `--workspace` is specified.

---

To fix the problem, there are two feasible ways:
1. Adding `--workspace` option to `cargo test`. 
2. Setting the cwd properly.

The first way is much slower than the second as it takes more time to filter out unnecessary tests outside current member packages.

So this commit passes the file directory as `Cmd.cwd` in CodeLens `Command` to *rls-vscode* so that `cargo test ...` can be executed with proper cwd.