### PR TITLE
Update rustfmt to 1.4.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,7 +1629,7 @@ dependencies = [
  "rls-vfs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-workspace-hack 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_tools_util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustfmt-nightly 1.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustfmt-nightly 1.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_ignored 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.4.10"
+version = "1.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "annotate-snippets 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2863,7 +2863,7 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustfix 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7150ac777a2931a53489f5a41eb0937b84e3092a20cd0e73ad436b65b507f607"
 "checksum rustfmt-config_proc_macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b19836fdb238d3f321427a41b87e6c2e9ac132f209d1dc55c55fae8d1df3996f"
-"checksum rustfmt-nightly 1.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "f53353c1c59a9a2acdee9cfd4254931873ae5ab0f7904761526d8de67682077f"
+"checksum rustfmt-nightly 1.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "170838c470a4e45aac8750515cae6313960ffbd9bfaefad7dc5633810e14fc51"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ racer = { version = "2.1.29", default-features = false }
 rand = "0.7"
 rayon = "1"
 rustc_tools_util = "0.2"
-rustfmt-nightly = "1.4.10"
+rustfmt-nightly = "1.4.11"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
This PR updates rustfmt to 1.4.11, which includes a bug fix for https://github.com/rust-lang/rustfmt/issues/3945.