### PR TITLE
Remove description() methods from Error trait impls

### DIFF
--- a/rls-analysis/src/lib.rs
+++ b/rls-analysis/src/lib.rs
@@ -550,18 +550,15 @@ impl ::std::fmt::Display for Id {
     }
 }
 
-impl ::std::error::Error for AError {
-    fn description(&self) -> &str {
-        match *self {
-            AError::MutexPoison => "poison error in a mutex (usually a secondary error)",
-            AError::Unclassified => "unknown error",
-        }
-    }
-}
+impl ::std::error::Error for AError {}
 
 impl ::std::fmt::Display for AError {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "{}", ::std::error::Error::description(self))
+        let description = match self {
+            AError::MutexPoison => "poison error in a mutex (usually a secondary error)",
+            AError::Unclassified => "unknown error",
+        };
+        write!(f, "{}", description)
     }
 }
 

--- a/rls-vfs/src/lib.rs
+++ b/rls-vfs/src/lib.rs
@@ -127,7 +127,7 @@ pub enum Error {
     InternalError(&'static str),
 }
 
-impl ::std::error::Error for Error {
+impl Error {
     fn description(&self) -> &str {
         match *self {
             Error::OutOfSync(ref _path_buf) => "file out of sync with filesystem",
@@ -148,7 +148,7 @@ impl ::std::error::Error for Error {
 
 impl Into<String> for Error {
     fn into(self) -> String {
-        ::std::error::Error::description(&self).to_owned()
+        self.description().to_owned()
     }
 }
 
@@ -166,7 +166,7 @@ impl fmt::Display for Error {
             | Error::FileNotCached
             | Error::NoUserDataForFile
             | Error::Io(..)
-            | Error::BadFileKind => f.write_str(::std::error::Error::description(self)),
+            | Error::BadFileKind => f.write_str(self.description()),
         }
     }
 }

--- a/rls/src/lsp_data.rs
+++ b/rls/src/lsp_data.rs
@@ -25,21 +25,18 @@ pub enum UrlFileParseError {
     InvalidFilePath,
 }
 
-impl Error for UrlFileParseError {
-    fn description(&self) -> &str {
-        match *self {
-            UrlFileParseError::InvalidScheme => "URI scheme is not `file`",
-            UrlFileParseError::InvalidFilePath => "Invalid file path in URI",
-        }
-    }
-}
+impl Error for UrlFileParseError {}
 
 impl fmt::Display for UrlFileParseError
 where
     UrlFileParseError: Error,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.description())
+        let description = match self {
+            UrlFileParseError::InvalidScheme => "URI scheme is not `file`",
+            UrlFileParseError::InvalidFilePath => "Invalid file path in URI",
+        };
+        write!(f, "{}", description)
     }
 }
 


### PR DESCRIPTION
We are getting ready to deprecate std::error::Error::description: https://github.com/rust-lang/rust/pull/66919. This PR replaces the three uses in this crate.