### PR TITLE
Correct two links to the json-error-emitter

### DIFF
--- a/rls-span/src/compiler.rs
+++ b/rls-span/src/compiler.rs
@@ -1,6 +1,6 @@
 ///! These are the structures emitted by the compiler as part of JSON errors.
 ///! The original source can be found at
-///! https://github.com/rust-lang/rust/blob/master/src/libsyntax/json.rs
+///! https://github.com/rust-lang/rust/blob/master/src/librustc_errors/json.rs
 use std::path::PathBuf;
 
 use crate::{Column, OneIndexed, Row, Span};

--- a/rls/src/actions/diagnostics.rs
+++ b/rls/src/actions/diagnostics.rs
@@ -2,7 +2,7 @@
 //!
 //! Data definitions for diagnostics can be found in the Rust compiler for:
 //! 1. Internal diagnostics at `src/librustc_errors/diagnostic.rs`.
-//! 2. Emitted JSON format at `src/libsyntax/json.rs`.
+//! 2. Emitted JSON format at `src/librustc_errors/json.rs`.
 
 use std::collections::HashMap;
 use std::iter;


### PR DESCRIPTION
Both links point to the old place of the error emitter

Closes #1604