### PR TITLE
Update Cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arc-swap"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,20 +161,20 @@ dependencies = [
 [[package]]
 name = "cargo"
 version = "0.43.0"
-source = "git+https://github.com/rust-lang/cargo?rev=86134e7666a088682f20b76278c3ee096a315218#86134e7666a088682f20b76278c3ee096a315218"
+source = "git+https://github.com/rust-lang/cargo?rev=735f648b35f5dd771a5b23a65bc465aee8639c56#735f648b35f5dd771a5b23a65bc465aee8639c56"
 dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cargo-platform 0.1.1 (git+https://github.com/rust-lang/cargo?rev=86134e7666a088682f20b76278c3ee096a315218)",
+ "cargo-platform 0.1.1 (git+https://github.com/rust-lang/cargo?rev=735f648b35f5dd771a5b23a65bc465aee8639c56)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crates-io 0.30.0 (git+https://github.com/rust-lang/cargo?rev=86134e7666a088682f20b76278c3ee096a315218)",
+ "crates-io 0.31.0 (git+https://github.com/rust-lang/cargo?rev=735f648b35f5dd771a5b23a65bc465aee8639c56)",
  "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-hash 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl-sys 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -195,7 +200,7 @@ dependencies = [
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-workspace-hack 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustfix 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustfix 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -216,7 +221,7 @@ dependencies = [
 [[package]]
 name = "cargo-platform"
 version = "0.1.1"
-source = "git+https://github.com/rust-lang/cargo?rev=86134e7666a088682f20b76278c3ee096a315218#86134e7666a088682f20b76278c3ee096a315218"
+source = "git+https://github.com/rust-lang/cargo?rev=735f648b35f5dd771a5b23a65bc465aee8639c56#735f648b35f5dd771a5b23a65bc465aee8639c56"
 dependencies = [
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -337,11 +342,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "crates-io"
-version = "0.30.0"
-source = "git+https://github.com/rust-lang/cargo?rev=86134e7666a088682f20b76278c3ee096a315218#86134e7666a088682f20b76278c3ee096a315218"
+version = "0.31.0"
+source = "git+https://github.com/rust-lang/cargo?rev=735f648b35f5dd771a5b23a65bc465aee8639c56#735f648b35f5dd771a5b23a65bc465aee8639c56"
 dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1603,13 +1608,13 @@ dependencies = [
 name = "rls"
 version = "1.41.0"
 dependencies = [
- "cargo 0.43.0 (git+https://github.com/rust-lang/cargo?rev=86134e7666a088682f20b76278c3ee096a315218)",
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo 0.43.0 (git+https://github.com/rust-lang/cargo?rev=735f648b35f5dd771a5b23a65bc465aee8639c56)",
  "cargo_metadata 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy_lints 0.0.212 (git+https://github.com/rust-lang/rust-clippy?rev=05b46034ea734f2b4436b700452771652ecc0074)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "home 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1920,10 +1925,10 @@ dependencies = [
 
 [[package]]
 name = "rustfix"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2678,6 +2683,7 @@ dependencies = [
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum annotate-snippets 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7021ce4924a3f25f802b2cccd1af585e39ea1a363a1aa2e72afe54b67a3a7a7"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
 "checksum arc-swap 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "854ede29f7a0ce90519fb2439d030320c6201119b87dab0ee96044603e1130b9"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
@@ -2695,8 +2701,8 @@ dependencies = [
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
-"checksum cargo 0.43.0 (git+https://github.com/rust-lang/cargo?rev=86134e7666a088682f20b76278c3ee096a315218)" = "<none>"
-"checksum cargo-platform 0.1.1 (git+https://github.com/rust-lang/cargo?rev=86134e7666a088682f20b76278c3ee096a315218)" = "<none>"
+"checksum cargo 0.43.0 (git+https://github.com/rust-lang/cargo?rev=735f648b35f5dd771a5b23a65bc465aee8639c56)" = "<none>"
+"checksum cargo-platform 0.1.1 (git+https://github.com/rust-lang/cargo?rev=735f648b35f5dd771a5b23a65bc465aee8639c56)" = "<none>"
 "checksum cargo_metadata 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "700b3731fd7d357223d0000f4dbf1808401b694609035c3c411fbc0cd375c426"
 "checksum cargo_metadata 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8d2d1617e838936c0d2323a65cc151e03ae19a7678dd24f72bccf27119b90a5d"
 "checksum cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
@@ -2709,7 +2715,7 @@ dependencies = [
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
 "checksum core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 "checksum core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
-"checksum crates-io 0.30.0 (git+https://github.com/rust-lang/cargo?rev=86134e7666a088682f20b76278c3ee096a315218)" = "<none>"
+"checksum crates-io 0.31.0 (git+https://github.com/rust-lang/cargo?rev=735f648b35f5dd771a5b23a65bc465aee8639c56)" = "<none>"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 "checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
@@ -2870,7 +2876,7 @@ dependencies = [
 "checksum rustc-workspace-hack 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc71d2faa173b74b232dedc235e3ee1696581bb132fc116fa3626d6151a1a8fb"
 "checksum rustc_tools_util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b725dadae9fabc488df69a287f5a99c5eaf5d10853842a8a3dfac52476f544ee"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum rustfix 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7150ac777a2931a53489f5a41eb0937b84e3092a20cd0e73ad436b65b507f607"
+"checksum rustfix 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "804b11883a5ce0ad0378fbf95a8dea59ee6b51c331a73b8f471b6bdaa3bd40c1"
 "checksum rustfmt-config_proc_macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b19836fdb238d3f321427a41b87e6c2e9ac132f209d1dc55c55fae8d1df3996f"
 "checksum rustfmt-nightly 1.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "170838c470a4e45aac8750515cae6313960ffbd9bfaefad7dc5633810e14fc51"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ rls-span = "0.5"
 rls-vfs = "0.8"
 rls-ipc = { version = "0.1.0", path = "rls-ipc", optional = true }
 
-cargo = { git = "https://github.com/rust-lang/cargo", rev = "86134e7666a088682f20b76278c3ee096a315218" }
+anyhow = "1.0.26"
+cargo = { git = "https://github.com/rust-lang/cargo", rev = "735f648b35f5dd771a5b23a65bc465aee8639c56" }
 cargo_metadata = "0.8"
 clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "05b46034ea734f2b4436b700452771652ecc0074", optional = true }
 env_logger = "0.7"
-failure = "0.1.1"
 futures = { version = "0.1", optional = true }
 home = "0.5.1"
 itertools = "0.8"

--- a/rls-rustc/src/ipc.rs
+++ b/rls-rustc/src/ipc.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::{Path, PathBuf};
 
-use failure::Fail;
 use futures::Future;
 
 use rls_ipc::client::{Client as JointClient, RpcChannel, RpcError};

--- a/rls/src/actions/format.rs
+++ b/rls/src/actions/format.rs
@@ -2,6 +2,7 @@
 //! possibly running Rustfmt binary specified by the user.
 
 use std::env::temp_dir;
+use std::fmt;
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -24,19 +25,32 @@ pub enum Rustfmt {
 }
 
 /// Defines a formatting-related error.
-#[derive(Fail, Debug)]
+#[derive(Debug)]
 pub enum Error {
     /// Generic variant of `Error::Rustfmt` error.
-    #[fail(display = "Formatting could not be completed.")]
     Failed,
-    #[fail(display = "Could not format source code: {}", _0)]
     Rustfmt(rustfmt_nightly::ErrorKind),
-    #[fail(display = "Encountered I/O error: {}", _0)]
     Io(std::io::Error),
-    #[fail(display = "Config couldn't be converted to TOML for Rustfmt purposes: {}", _0)]
     ConfigTomlOutput(String),
-    #[fail(display = "Formatted output is not valid UTF-8 source: {}", _0)]
     OutputNotUtf8(FromUtf8Error),
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Failed => write!(f, "Formatting could not be completed."),
+            Error::Rustfmt(err) => write!(f, "Could not format source code: {}", err),
+            Error::Io(err) => write!(f, "Encountered I/O error: {}", err),
+            Error::ConfigTomlOutput(err) => {
+                write!(f, "Config couldn't be converted to TOML for Rustfmt purposes: {}", err)
+            }
+            Error::OutputNotUtf8(err) => {
+                write!(f, "Formatted output is not valid UTF-8 source: {}", err)
+            }
+        }
+    }
 }
 
 impl From<std::io::Error> for Error {

--- a/rls/src/actions/mod.rs
+++ b/rls/src/actions/mod.rs
@@ -219,7 +219,7 @@ impl InitActionContext {
         *self.project_model.lock().unwrap() = None;
     }
 
-    pub fn project_model(&self) -> Result<Arc<ProjectModel>, failure::Error> {
+    pub fn project_model(&self) -> Result<Arc<ProjectModel>, anyhow::Error> {
         let cached: Option<Arc<ProjectModel>> = self.project_model.lock().unwrap().clone();
         match cached {
             Some(pm) => Ok(pm),

--- a/rls/src/actions/post_build.rs
+++ b/rls/src/actions/post_build.rs
@@ -19,7 +19,6 @@ use crate::concurrency::JobToken;
 use crate::config::CrateBlacklist;
 use crate::lsp_data::{PublishDiagnosticsParams, Range};
 
-use failure;
 use itertools::Itertools;
 use log::{trace, warn};
 use lsp_types::DiagnosticSeverity;
@@ -108,7 +107,7 @@ impl PostBuildHandler {
         &self,
         manifest: PathBuf,
         manifest_error_range: Option<Range>,
-        error: &failure::Error,
+        error: &anyhow::Error,
         stdout: &str,
     ) {
         use crate::lsp_data::Position;
@@ -125,7 +124,7 @@ impl PostBuildHandler {
             .unwrap_or_else(|| Range { start: Position::new(0, 0), end: Position::new(9999, 0) });
 
         let mut message = format!("{}", error);
-        for cause in error.iter_causes() {
+        for cause in error.chain().skip(1) {
             write!(message, "\n{}", cause).unwrap();
         }
         if !stdout.trim().is_empty() {

--- a/rls/src/build/cargo.rs
+++ b/rls/src/build/cargo.rs
@@ -20,7 +20,6 @@ use cargo::util::{
     config as cargo_config, errors::ManifestError, homedir, important_paths, CargoResult,
     ConfigValue, ProcessBuilder,
 };
-use failure::{self, format_err, Fail};
 use log::{debug, trace, warn};
 use rls_data::Analysis;
 use rls_vfs::Vfs;
@@ -75,7 +74,7 @@ pub(super) fn cargo(
         }
     });
 
-    match handle.join().map_err(|_| failure::err_msg("thread panicked")).and_then(|res| res) {
+    match handle.join().map_err(|_| anyhow::Error::msg("thread panicked")).and_then(|res| res) {
         Ok(ref cwd) => {
             let diagnostics = Arc::try_unwrap(diagnostics).unwrap().into_inner().unwrap();
             let analysis = Arc::try_unwrap(analysis).unwrap().into_inner().unwrap();
@@ -105,7 +104,7 @@ fn run_cargo(
     input_files: Arc<Mutex<HashMap<PathBuf, HashSet<Crate>>>>,
     out: Arc<Mutex<Vec<u8>>>,
     progress_sender: Sender<ProgressUpdate>,
-) -> Result<PathBuf, failure::Error> {
+) -> Result<PathBuf, anyhow::Error> {
     // Lock early to guarantee synchronized access to env var for the scope of Cargo routine.
     // Additionally we need to pass inner lock to `RlsExecutor`, since it needs to hand it down
     // during `exec()` callback when calling linked compiler in parallel, for which we need to
@@ -281,7 +280,7 @@ fn run_cargo_ws(
     }
 
     if !reached_primary.load(Ordering::SeqCst) {
-        return Err(format_err!("error compiling dependent crate"));
+        return Err(anyhow::format_err!("error compiling dependent crate"));
     }
 
     Ok(compilation_cx
@@ -577,7 +576,7 @@ impl Executor for RlsExecutor {
             }
 
             if !success {
-                return Err(format_err!("Build error"));
+                return Err(anyhow::format_err!("Build error"));
             }
         }
 
@@ -791,14 +790,14 @@ fn filter_arg(args: &[OsString], key: &str) -> Vec<String> {
 /// Error wrapper that tries to figure out which manifest the cause best relates to in the project
 #[derive(Debug)]
 pub struct ManifestAwareError {
-    cause: failure::Error,
+    cause: anyhow::Error,
     /// The path to a manifest file within the project that seems the closest to the error's origin.
     nearest_project_manifest: PathBuf,
     manifest_error_range: Range,
 }
 
 impl ManifestAwareError {
-    fn new(cause: failure::Error, root_manifest: &Path, ws: Option<&Workspace<'_>>) -> Self {
+    fn new(cause: anyhow::Error, root_manifest: &Path, ws: Option<&Workspace<'_>>) -> Self {
         let project_dir = root_manifest.parent().unwrap();
         let mut err_path = root_manifest;
         // Cover whole manifest if we haven't any better idea.
@@ -813,12 +812,16 @@ impl ManifestAwareError {
             if is_project_manifest(last_cause.manifest_path()) {
                 // Manifest with the issue is inside the project.
                 err_path = last_cause.manifest_path().as_path();
-                if let Some((line, col)) = (last_cause as &dyn Fail)
-                    .iter_chain()
-                    .filter_map(|e| e.downcast_ref::<toml::de::Error>())
-                    .next()
-                    .and_then(|e| e.line_col())
-                {
+                // This can be replaced by Error::chain when it is stabilized.
+                fn find_toml_error(
+                    err: &(dyn std::error::Error + 'static),
+                ) -> Option<(usize, usize)> {
+                    match err.downcast_ref::<toml::de::Error>() {
+                        Some(toml_err) => toml_err.line_col(),
+                        None => find_toml_error(err.source()?),
+                    }
+                }
+                if let Some((line, col)) = find_toml_error(last_cause) {
                     // Use TOML deserializiation error position.
                     err_range.start = Position::new(line as _, col as _);
                     err_range.end = Position::new(line as _, col as u64 + 1);
@@ -862,11 +865,7 @@ impl fmt::Display for ManifestAwareError {
         self.cause.fmt(f)
     }
 }
-impl failure::Fail for ManifestAwareError {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.cause.as_fail().cause()
-    }
-}
+impl std::error::Error for ManifestAwareError {}
 
 #[cfg(test)]
 mod test {

--- a/rls/src/build/mod.rs
+++ b/rls/src/build/mod.rs
@@ -10,7 +10,6 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use failure;
 use log::{debug, info, trace};
 use rls_data::Analysis;
 use rls_vfs::Vfs;
@@ -105,7 +104,7 @@ pub enum BuildResult {
     Err(String, Option<String>),
     /// Cargo failed.
     CargoError {
-        error: failure::Error,
+        error: anyhow::Error,
         stdout: String,
         manifest_path: Option<PathBuf>,
         manifest_error_range: Option<Range>,

--- a/rls/src/lib.rs
+++ b/rls/src/lib.rs
@@ -10,9 +10,6 @@
 #![warn(clippy::all, clippy::clone_on_ref_ptr)]
 #![allow(clippy::cognitive_complexity, clippy::too_many_arguments, clippy::redundant_closure)]
 
-#[macro_use]
-extern crate failure;
-
 pub use rls_analysis::{AnalysisHost, Target};
 pub use rls_vfs::Vfs;
 

--- a/rls/src/project_model.rs
+++ b/rls/src/project_model.rs
@@ -42,7 +42,7 @@ pub struct Dep {
 }
 
 impl ProjectModel {
-    pub fn load(ws_manifest: &Path, vfs: &Vfs) -> Result<ProjectModel, failure::Error> {
+    pub fn load(ws_manifest: &Path, vfs: &Vfs) -> Result<ProjectModel, anyhow::Error> {
         assert!(ws_manifest.ends_with("Cargo.toml"));
         let mut config = Config::default()?;
         // Enable nightly flag for cargo(see #1043)


### PR DESCRIPTION
Cargo has switched from `failure` to `anyhow`.  There was only one other place using failure (`src/actions/format.rs`), so I went ahead and switched that too (rustfmt uses `anyhow`, too).
