### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -64,7 +64,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 dependencies = [
  "libc",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -103,9 +103,9 @@ checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "bitflags"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitmaps"
@@ -177,7 +177,7 @@ dependencies = [
 [[package]]
 name = "cargo"
 version = "0.44.0"
-source = "git+https://github.com/rust-lang/cargo?rev=972b9f55a72e3eae21c826b2f806c753696ef2ec#972b9f55a72e3eae21c826b2f806c753696ef2ec"
+source = "git+https://github.com/rust-lang/cargo?rev=e02974078a692d7484f510eaec0e88d1b6cc0203#e02974078a692d7484f510eaec0e88d1b6cc0203"
 dependencies = [
  "anyhow",
  "atty",
@@ -232,13 +232,13 @@ dependencies = [
  "unicode-width",
  "url 2.1.0",
  "walkdir",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "cargo-platform"
 version = "0.1.1"
-source = "git+https://github.com/rust-lang/cargo?rev=972b9f55a72e3eae21c826b2f806c753696ef2ec#972b9f55a72e3eae21c826b2f806c753696ef2ec"
+source = "git+https://github.com/rust-lang/cargo?rev=e02974078a692d7484f510eaec0e88d1b6cc0203#e02974078a692d7484f510eaec0e88d1b6cc0203"
 dependencies = [
  "serde",
 ]
@@ -313,7 +313,7 @@ dependencies = [
  "regex-syntax",
  "semver",
  "serde",
- "smallvec 1.0.0",
+ "smallvec 1.2.0",
  "toml",
  "unicode-normalization",
  "url 2.1.0",
@@ -371,7 +371,7 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 [[package]]
 name = "crates-io"
 version = "0.31.0"
-source = "git+https://github.com/rust-lang/cargo?rev=972b9f55a72e3eae21c826b2f806c753696ef2ec#972b9f55a72e3eae21c826b2f806c753696ef2ec"
+source = "git+https://github.com/rust-lang/cargo?rev=e02974078a692d7484f510eaec0e88d1b6cc0203#e02974078a692d7484f510eaec0e88d1b6cc0203"
 dependencies = [
  "anyhow",
  "curl",
@@ -463,7 +463,7 @@ dependencies = [
  "commoncrypto",
  "hex 0.3.2",
  "openssl",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -478,7 +478,7 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -494,7 +494,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -550,7 +550,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_users",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -625,7 +625,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -669,7 +669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -807,7 +807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3753954f7bd71f0e671afb8b5a992d1724cf43b7f95a563cd4a0bde94659ca8"
 dependencies = [
  "scopeguard",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -918,13 +918,11 @@ checksum = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 
 [[package]]
 name = "jobserver"
-version = "0.1.16"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f74e73053eaf95399bf926e48fc7a2a3ce50bd0eaaa2357d391e95b2dcdd4f10"
+checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 dependencies = [
  "libc",
- "log",
- "rand",
 ]
 
 [[package]]
@@ -1155,10 +1153,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "measureme"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef709d3257013bba7cff14fc504e07e80631d3fe0f6d38ce63b8f6510ccb932"
+dependencies = [
+ "byteorder",
+ "memmap",
+ "parking_lot",
+ "rustc-hash",
+]
+
+[[package]]
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+
+[[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "memoffset"
@@ -1205,7 +1225,7 @@ dependencies = [
  "log",
  "mio",
  "miow 0.3.3",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1238,7 +1258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
 dependencies = [
  "socket2",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1249,7 +1269,7 @@ checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 dependencies = [
  "cfg-if",
  "libc",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1267,7 +1287,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998c59e83d9474c01127a96e023b7a04bb061dd286bf8bb939d31dc8d31a7448"
 dependencies = [
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1324,7 +1344,7 @@ dependencies = [
  "tokio",
  "tokio-named-pipes",
  "tokio-uds",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1350,7 +1370,7 @@ dependencies = [
  "redox_syscall",
  "rustc_version",
  "smallvec 0.6.10",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1441,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "racer"
-version = "2.1.30"
+version = "2.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e9de5b4aedb212b93d75c02ac6d35df85b2db0edd85fbc6a61c073348aae2c"
+checksum = "0ff33fa15ac0384376741d16ddb05a65263dde4e2c5d0f7a9f3747db788764aa"
 dependencies = [
  "bitflags",
  "clap",
@@ -1453,6 +1473,12 @@ dependencies = [
  "lazy_static",
  "log",
  "rls-span",
+ "rustc-ap-rustc_ast_pretty",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_errors",
+ "rustc-ap-rustc_parse",
+ "rustc-ap-rustc_session",
+ "rustc-ap-rustc_span",
  "rustc-ap-syntax",
 ]
 
@@ -1571,7 +1597,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 dependencies = [
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1709,26 +1735,57 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "610.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7475f4c707269b56eb7144c53591e3cd6369a5aa1d66434829ea11df96d5e7e3"
+checksum = "ea82fa3d9a8add7422228ca1a2cbba0784fa8861f56148ff64da08b3c7921b03"
 dependencies = [
  "rustc-ap-rustc_data_structures",
- "smallvec 0.6.10",
+ "smallvec 1.2.0",
 ]
 
 [[package]]
 name = "rustc-ap-graphviz"
-version = "610.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e59a55520f140a70a3e0fad80a36e807caa85e9d7016167b91a5b521ea929be"
+checksum = "638d0b2b3bcf99824e0cb5a25dbc547b61dc20942e11daf6a97e981918aa18e5"
+
+[[package]]
+name = "rustc-ap-rustc_ast_pretty"
+version = "642.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38bab04dd676dee6d2f9670506a18c31bfce38bf7f8420aa83eb1140ecde049"
+dependencies = [
+ "log",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_span",
+ "rustc-ap-syntax",
+]
+
+[[package]]
+name = "rustc-ap-rustc_attr"
+version = "642.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b843ba8b1ed43739133047673b9f6a54d3b3b4d328d69c6ea89ff971395f35"
+dependencies = [
+ "rustc-ap-rustc_ast_pretty",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_errors",
+ "rustc-ap-rustc_feature",
+ "rustc-ap-rustc_macros",
+ "rustc-ap-rustc_session",
+ "rustc-ap-rustc_span",
+ "rustc-ap-serialize",
+ "rustc-ap-syntax",
+ "smallvec 1.2.0",
+]
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "610.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6420857d5a088f680ec1ba736ffba4ee9c1964b0d397e6318f38d461f4f7d5cb"
+checksum = "dc3d1c6d0a80ab0c1df76405377cec0f3d5423fb5b0953a8eac70a2ad6c44df2"
 dependencies = [
+ "bitflags",
  "cfg-if",
  "crossbeam-utils 0.6.5",
  "ena",
@@ -1736,6 +1793,7 @@ dependencies = [
  "jobserver",
  "lazy_static",
  "log",
+ "measureme",
  "parking_lot",
  "rustc-ap-graphviz",
  "rustc-ap-rustc_index",
@@ -1743,51 +1801,70 @@ dependencies = [
  "rustc-hash",
  "rustc-rayon",
  "rustc-rayon-core",
- "smallvec 0.6.10",
+ "smallvec 1.2.0",
  "stable_deref_trait",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "610.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8abfca0960131262254a91d02ff4903526a261ede730d7a2c75b4234c867cdc0"
+checksum = "4909a1eca29331332257230f29120a8ff68c9e37d868c564fcd599e430cf8914"
 dependencies = [
  "annotate-snippets",
  "atty",
  "log",
  "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_span",
  "rustc-ap-serialize",
- "rustc-ap-syntax_pos",
- "term_size",
  "termcolor",
+ "termize",
  "unicode-width",
+ "winapi 0.3.8",
 ]
 
 [[package]]
-name = "rustc-ap-rustc_index"
-version = "610.0.0"
+name = "rustc-ap-rustc_feature"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a395509dcb90a92c1479c085639594624e06b4ab3fc7c1b795b46a61f2d4f65"
+checksum = "63ab887a181d795cf5fd3edadf367760deafb90aefb844f168ab5255266e3478"
+dependencies = [
+ "lazy_static",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_span",
+]
+
+[[package]]
+name = "rustc-ap-rustc_fs_util"
+version = "642.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70814116df3c5fbec8f06f6a1d013ca481f620fd22a9475754e9bf3ee9ba70d8"
+
+[[package]]
+name = "rustc-ap-rustc_index"
+version = "642.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1bf1d3cf3d119d41353d6fd229ef7272d5097bc0924de021c0294bf86d48bf"
 dependencies = [
  "rustc-ap-serialize",
- "smallvec 0.6.10",
+ "smallvec 1.2.0",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "610.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64eac8a0e6efb8f55292aa24be0208c7c0538236c613e79952fd1fa3d54bcf8e"
+checksum = "4cda21a32cebdc11ec4f5393aa2fcde5ed1b2f673a8571e5a4dcdf07e4ae9cac"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "610.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99795e8be4877e9e05d59f201e1740c1cf673364655def5848606d9e25b75af"
+checksum = "75c47b48ea51910ecfd853c9248a9bf4c767bc823449ab6a1d864dff65fbae16"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1797,56 +1874,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-ap-rustc_target"
-version = "610.0.0"
+name = "rustc-ap-rustc_parse"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22e21fdd8e1c0030f507158fa79b9f1e080e6241aba994d0f97c14a0a07a826"
+checksum = "abd88e89cd5b5d28dcd3a347a3d534c08627d9455570dc1a2d402cb8437b9d30"
 dependencies = [
  "bitflags",
  "log",
- "rustc-ap-rustc_data_structures",
- "rustc-ap-rustc_index",
- "rustc-ap-serialize",
- "rustc-ap-syntax_pos",
-]
-
-[[package]]
-name = "rustc-ap-serialize"
-version = "610.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1cd6ef5135408d62559866e79986ca261f4c1333253d500e5e66fe66d1432e"
-dependencies = [
- "indexmap",
- "smallvec 0.6.10",
-]
-
-[[package]]
-name = "rustc-ap-syntax"
-version = "610.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fc1c901d2cbd24cae95d7bc5a58aa7661ec3dc5320c78c32830a52a685c33c"
-dependencies = [
- "bitflags",
- "lazy_static",
- "log",
+ "rustc-ap-rustc_ast_pretty",
+ "rustc-ap-rustc_attr",
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_errors",
- "rustc-ap-rustc_index",
+ "rustc-ap-rustc_feature",
  "rustc-ap-rustc_lexer",
- "rustc-ap-rustc_target",
- "rustc-ap-serialize",
- "rustc-ap-syntax_pos",
- "scoped-tls",
- "smallvec 0.6.10",
+ "rustc-ap-rustc_session",
+ "rustc-ap-rustc_span",
+ "rustc-ap-syntax",
+ "smallvec 1.2.0",
+ "unicode-normalization",
 ]
 
 [[package]]
-name = "rustc-ap-syntax_pos"
-version = "610.0.0"
+name = "rustc-ap-rustc_session"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230534f638255853bb9f13987537e00a818435a0cc54b68d97221b6822c8f1bc"
+checksum = "5b8487b4575fbb2d1fc6f1cd61225efd108a4d36817e6fb9b643d57fcae9cb12"
+dependencies = [
+ "log",
+ "num_cpus",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_errors",
+ "rustc-ap-rustc_feature",
+ "rustc-ap-rustc_fs_util",
+ "rustc-ap-rustc_index",
+ "rustc-ap-rustc_span",
+ "rustc-ap-rustc_target",
+ "rustc-ap-serialize",
+ "rustc-ap-syntax",
+]
+
+[[package]]
+name = "rustc-ap-rustc_span"
+version = "642.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f69746c0d4c21bf20a5bb2bd247261a1aa8631f04202d7303352942dde70d987"
 dependencies = [
  "cfg-if",
+ "log",
  "rustc-ap-arena",
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_index",
@@ -1854,6 +1928,48 @@ dependencies = [
  "rustc-ap-serialize",
  "scoped-tls",
  "unicode-width",
+]
+
+[[package]]
+name = "rustc-ap-rustc_target"
+version = "642.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bbc6ae09b5d42ec66edd520e8412e0615c53a7c93607fe33dc4abab60ba7c8b"
+dependencies = [
+ "bitflags",
+ "log",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_index",
+ "rustc-ap-rustc_macros",
+ "rustc-ap-rustc_span",
+ "rustc-ap-serialize",
+]
+
+[[package]]
+name = "rustc-ap-serialize"
+version = "642.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13a1ead0252fc3d96da4c336a95950be6795f2b00c84a67ccadf26142f8cb41"
+dependencies = [
+ "indexmap",
+ "smallvec 1.2.0",
+]
+
+[[package]]
+name = "rustc-ap-syntax"
+version = "642.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1f59f48ca3a2ec16a7e82e718ed5aadf9c9e08cf63015d28b4e774767524a6a"
+dependencies = [
+ "log",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_index",
+ "rustc-ap-rustc_lexer",
+ "rustc-ap-rustc_macros",
+ "rustc-ap-rustc_span",
+ "rustc-ap-serialize",
+ "scoped-tls",
+ "smallvec 1.2.0",
 ]
 
 [[package]]
@@ -1941,9 +2057,9 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.4.11"
+version = "1.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170838c470a4e45aac8750515cae6313960ffbd9bfaefad7dc5633810e14fc51"
+checksum = "1c12d408c9cfeb90fce5d44f05a2f0a3ee0513ca58623cf230ae0236181da317"
 dependencies = [
  "annotate-snippets",
  "bytecount",
@@ -1958,9 +2074,14 @@ dependencies = [
  "itertools",
  "log",
  "regex",
+ "rustc-ap-rustc_ast_pretty",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_errors",
+ "rustc-ap-rustc_parse",
+ "rustc-ap-rustc_session",
+ "rustc-ap-rustc_span",
  "rustc-ap-rustc_target",
  "rustc-ap-syntax",
- "rustc-ap-syntax_pos",
  "rustc-workspace-hack",
  "rustfmt-config_proc_macro",
  "serde",
@@ -1995,7 +2116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
 dependencies = [
  "lazy_static",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2127,9 +2248,9 @@ checksum = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 
 [[package]]
 name = "smallvec"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
+checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 
 [[package]]
 name = "socket2"
@@ -2140,7 +2261,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2232,7 +2353,7 @@ dependencies = [
  "rand",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2242,18 +2363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 dependencies = [
  "dirs",
- "winapi 0.3.7",
-]
-
-[[package]]
-name = "term_size"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
-dependencies = [
- "kernel32-sys",
- "libc",
- "winapi 0.2.8",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2263,6 +2373,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 dependencies = [
  "wincolor",
+]
+
+[[package]]
+name = "termize"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1706be6b564323ce7092f5f7e6b118a14c8ef7ed0e69c8c5329c914a9f101295"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2398,7 +2518,7 @@ dependencies = [
  "tokio-io",
  "tokio-reactor",
  "tokio-signal",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2443,7 +2563,7 @@ dependencies = [
  "tokio-executor",
  "tokio-io",
  "tokio-reactor",
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2567,11 +2687,11 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.8"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
+checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 0.6.10",
+ "smallvec 1.2.0",
 ]
 
 [[package]]
@@ -2661,7 +2781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 dependencies = [
  "same-file",
- "winapi 0.3.7",
+ "winapi 0.3.8",
  "winapi-util",
 ]
 
@@ -2679,9 +2799,9 @@ checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
+checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -2705,7 +2825,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 dependencies = [
- "winapi 0.3.7",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2720,7 +2840,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
 dependencies = [
- "winapi 0.3.7",
+ "winapi 0.3.8",
  "winapi-util",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rls-vfs = "0.8"
 rls-ipc = { version = "0.1.0", path = "rls-ipc", optional = true }
 
 anyhow = "1.0.26"
-cargo = { git = "https://github.com/rust-lang/cargo", rev = "972b9f55a72e3eae21c826b2f806c753696ef2ec" }
+cargo = { git = "https://github.com/rust-lang/cargo", rev = "e02974078a692d7484f510eaec0e88d1b6cc0203" }
 cargo_metadata = "0.8"
 clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "05b46034ea734f2b4436b700452771652ecc0074", optional = true }
 env_logger = "0.7"
@@ -46,7 +46,7 @@ racer = { version = "2.1.31", default-features = false }
 rand = "0.7"
 rayon = "1"
 rustc_tools_util = "0.2"
-rustfmt-nightly = "1.4.11"
+rustfmt-nightly = "1.4.12"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/rls/src/build/cargo.rs
+++ b/rls/src/build/cargo.rs
@@ -110,7 +110,7 @@ fn run_cargo(
     // during `exec()` callback when calling linked compiler in parallel, for which we need to
     // guarantee consistent environment variables.
     let (lock_guard, inner_lock) = env_lock.lock();
-    let restore_env = Environment::push_with_lock(&HashMap::new(), None, lock_guard);
+    let restore_env = Environment::push_with_lock(&BTreeMap::new(), None, lock_guard);
 
     let build_dir = compilation_cx.lock().unwrap().build_dir.clone().unwrap();
 

--- a/rls/src/build/environment.rs
+++ b/rls/src/build/environment.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::env;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -14,19 +14,19 @@ lazy_static! {
 /// An RAII helper to set and reset the env vars.
 /// Requires supplying an external lock guard to guarantee env var consistency across multiple threads.
 pub struct Environment<'a> {
-    old_vars: HashMap<String, Option<OsString>>,
+    old_vars: BTreeMap<String, Option<OsString>>,
     old_cwd: PathBuf,
     _guard: MutexGuard<'a, ()>,
 }
 
 impl<'a> Environment<'a> {
     pub fn push_with_lock(
-        envs: &HashMap<String, Option<OsString>>,
+        envs: &BTreeMap<String, Option<OsString>>,
         cwd: Option<&Path>,
         lock: MutexGuard<'a, ()>,
     ) -> Environment<'a> {
         let mut result = Environment {
-            old_vars: HashMap::new(),
+            old_vars: BTreeMap::new(),
             old_cwd: env::current_dir().expect("failed to read cwd"),
             _guard: lock,
         };

--- a/rls/src/build/rustc.rs
+++ b/rls/src/build/rustc.rs
@@ -21,7 +21,7 @@ extern crate rustc_save_analysis;
 #[allow(unused_extern_crates)]
 extern crate rustc_span;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::ffi::OsString;
 use std::io;
@@ -52,7 +52,7 @@ use crate::config::{ClippyPreference, Config};
 pub(crate) fn rustc(
     vfs: &Vfs,
     args: &[String],
-    envs: &HashMap<String, Option<OsString>>,
+    envs: &BTreeMap<String, Option<OsString>>,
     cwd: Option<&Path>,
     build_dir: &Path,
     rls_config: Arc<Mutex<Config>>,


### PR DESCRIPTION
Cargo has switched to BTreeMap for env vars for reproducibility.

Note: I had to update rustfmt-nightly to get the lock file to update properly.  I'm not sure what happened with #1631, but there were a lot of conflicts with the rustc-ap-* crates pulling in two different versions.  It looks like rust-lang/rust is already updated to the correct version.

Closes #1637