### PR TITLE
By default use out-of-process compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,6 @@ version = "0.6.0"
 dependencies = [
  "clippy_lints 0.0.212 (git+https://github.com/rust-lang/rust-clippy?rev=d236b30a1d638340aad8345fa2946cfe9543dcf0)",
  "env_logger 0.7.1",
- "failure",
  "futures",
  "log",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,4 +80,4 @@ rustc_tools_util = "0.2"
 [features]
 clippy = ["clippy_lints", "rls-rustc/clippy"]
 ipc = ["tokio", "futures", "rls-rustc/ipc", "rls-ipc/server"]
-default = []
+default = ["ipc"]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,5 +40,5 @@ jobs:
       ".":
         - test_name: test_tooltip_std
           test_args: --ignored
-      # Test also the IPC feature build
-        - args: --features ipc
+      # Test that we don't regress in-process compilation build
+        - args: --no-default-features

--- a/rls-rustc/Cargo.toml
+++ b/rls-rustc/Cargo.toml
@@ -14,7 +14,6 @@ log = "0.4"
 rand = "0.7"
 clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "d236b30a1d638340aad8345fa2946cfe9543dcf0", optional = true }
 tokio = { version = "0.1", optional = true }
-failure = { version = "0.1" }
 futures = { version = "0.1", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 rls-data = { version = "0.19", optional = true }

--- a/rls-rustc/src/ipc.rs
+++ b/rls-rustc/src/ipc.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::{Path, PathBuf};
 
-use failure::Fail;
 use futures::Future;
 
 use rls_ipc::client::{Client as JointClient, RpcChannel, RpcError};
@@ -38,7 +37,7 @@ impl rustc_span::source_map::FileLoader for IpcFileLoader {
         self.0
             .read_file(path.to_owned())
             .wait()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.compat()))
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{}", e)))
     }
 }
 


### PR DESCRIPTION
This should prevent memory leaks which probably happen in cargo/rustc, which are not intended to be running as a long-running process.

Refs: #1188