### PR TITLE
Update Clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rls-ipc = { version = "0.1.0", path = "rls-ipc", optional = true }
 anyhow = "1.0.26"
 cargo = { git = "https://github.com/rust-lang/cargo", rev = "258c89644c4587273a3ed3ee9522d2640facba43" }
 cargo_metadata = "0.8"
-clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "28197b622611ba3a6367648974ccf59127c287bb", optional = true }
+clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "7ea7cd165ad6705603852771bf82cc2fd6560db5", optional = true }
 env_logger = "0.7"
 futures = { version = "0.1", optional = true }
 home = "0.5.1"

--- a/rls-rustc/src/clippy.rs
+++ b/rls-rustc/src/clippy.rs
@@ -59,7 +59,7 @@ pub fn config(config: &mut rustc_interface::interface::Config) {
 
         let conf = clippy_lints::read_conf(&[], &sess);
         clippy_lints::register_plugins(&mut lint_store, &sess, &conf);
-        clippy_lints::register_pre_expansion_lints(&mut lint_store, &conf);
+        clippy_lints::register_pre_expansion_lints(&mut lint_store);
         clippy_lints::register_renamed(&mut lint_store);
     }));
 }

--- a/rls/src/build/rustc.rs
+++ b/rls/src/build/rustc.rs
@@ -326,7 +326,7 @@ fn clippy_config(config: &mut interface::Config) {
 
         let conf = clippy_lints::read_conf(&[], &sess);
         clippy_lints::register_plugins(&mut lint_store, &sess, &conf);
-        clippy_lints::register_pre_expansion_lints(&mut lint_store, &conf);
+        clippy_lints::register_pre_expansion_lints(&mut lint_store);
         clippy_lints::register_renamed(&mut lint_store);
     }));
 }


### PR DESCRIPTION
This updates Clippy in preparation to rust-lang/rust#72671

This should be branched, so I can use it to update the submodule in rust-lang/rust#72671, and then merged after rust-lang/rust#72671 is merged. (Or whatever the process is for this is)

r? @Xanewok 