### PR TITLE
itertools = 0.9, fst = 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,12 +133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
 
 [[package]]
-name = "byteorder"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
-
-[[package]]
 name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,7 +156,7 @@ dependencies = [
  "cargo-util",
  "clap",
  "crates-io",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.3",
  "curl",
  "curl-sys",
  "env_logger 0.8.2",
@@ -356,12 +350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,12 +401,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.3",
 ]
 
 [[package]]
@@ -439,8 +427,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.1",
- "crossbeam-utils 0.8.1",
+ "crossbeam-epoch 0.9.3",
+ "crossbeam-utils 0.8.3",
 ]
 
 [[package]]
@@ -460,15 +448,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
 dependencies = [
  "cfg-if 1.0.0",
- "const_fn",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.3",
  "lazy_static",
- "memoffset 0.6.1",
+ "memoffset 0.6.3",
  "scopeguard",
 ]
 
@@ -496,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
@@ -724,12 +711,9 @@ dependencies = [
 
 [[package]]
 name = "fst"
-version = "0.3.5"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927fb434ff9f0115b215dc0efd2e4fbdd7448522a92a1aa37c77d6a2f8f1ebd6"
-dependencies = [
- "byteorder",
-]
+checksum = "d79238883cf0307100b90aba4a755d8051a3182305dfe7f649a1e9dc0517006f"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -1041,7 +1025,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b287fb45c60bb826a0dc68ff08742b9d88a2fea13d6e0c286b3172065aaf878c"
 dependencies = [
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.3",
  "globset",
  "lazy_static",
  "log",
@@ -1130,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "json"
-version = "0.11.15"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c245af8786f6ac35f95ca14feca9119e71339aaab41e878e7cdd655c97e9e5"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "jsonrpc-client-transports"
@@ -1259,9 +1243,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.91"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
+checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
 name = "libgit2-sys"
@@ -1419,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
 dependencies = [
  "autocfg",
 ]
@@ -1901,7 +1885,7 @@ checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.3",
  "lazy_static",
  "num_cpus",
 ]
@@ -1974,7 +1958,7 @@ dependencies = [
  "futures 0.3.12",
  "heck",
  "home",
- "itertools 0.8.2",
+ "itertools 0.9.0",
  "jsonrpc-core",
  "lazy_static",
  "log",
@@ -2009,13 +1993,11 @@ dependencies = [
 
 [[package]]
 name = "rls-analysis"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534032993e1b60e5db934eab2dde54da7afd1e46c3465fddb2b29eb47cb1ed3a"
+version = "0.18.2"
 dependencies = [
  "derive-new",
  "fst",
- "itertools 0.8.2",
+ "itertools 0.9.0",
  "json",
  "log",
  "rls-data",
@@ -2089,7 +2071,7 @@ dependencies = [
  "base64",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ test = false
 path = "rls/src/main.rs"
 
 [dependencies]
-rls-analysis = "0.18.1"
+# FIXME: Release rls-analysis 0.18.2 to crates.io
+rls-analysis = { version = "0.18.2", path = "rls-analysis" }
 rls-data = "0.19"
 # FIXME: Release rls-rustc 0.6.0 to crates.io
 rls-rustc = { version = "0.6.0", path = "rls-rustc" }
@@ -36,7 +37,7 @@ cargo_metadata = "0.8"
 clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", rev = "7ea7cd165ad6705603852771bf82cc2fd6560db5", optional = true }
 env_logger = "0.7"
 home = "0.5.1"
-itertools = "0.8"
+itertools = "0.9"
 jsonrpc-core = "17"
 lsp-types = { version = "0.60", features = ["proposed"] }
 lazy_static = "1"

--- a/rls-analysis/Cargo.toml
+++ b/rls-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rls-analysis"
-version = "0.18.1"
+version = "0.18.2"
 edition = "2018"
 authors = ["Nick Cameron <ncameron@mozilla.com>"]
 description = "Library for processing rustc's save-analysis data for the RLS"
@@ -21,8 +21,8 @@ log = "0.4"
 rls-data = "= 0.19"
 rls-span = "0.5.2"
 derive-new = "0.5"
-fst = { version = "0.3", default-features = false }
-itertools = "0.8"
+fst = { version = "0.4", default-features = false }
+itertools = "0.9"
 json = "0.12"
 serde = "1.0"
 serde_json = "1.0"

--- a/rls-analysis/src/analysis.rs
+++ b/rls-analysis/src/analysis.rs
@@ -42,7 +42,7 @@ pub struct PerCrateAnalysis {
 
     // Index of all symbols that powers the search.
     // See `SymbolQuery`.
-    pub def_fst: fst::Map,
+    pub def_fst: fst::Map<Vec<u8>>,
     pub def_fst_values: Vec<Vec<Id>>,
 
     pub ref_spans: HashMap<Id, Vec<Span>>,

--- a/rls-analysis/src/lowering.rs
+++ b/rls-analysis/src/lowering.rs
@@ -514,7 +514,7 @@ fn abs_ref_id<L: AnalysisLoader>(
     None
 }
 
-fn build_index(mut defs: Vec<(String, Id)>) -> (fst::Map, Vec<Vec<Id>>) {
+fn build_index(mut defs: Vec<(String, Id)>) -> (fst::Map<Vec<u8>>, Vec<Vec<Id>>) {
     defs.sort_by(|(n1, _), (n2, _)| n1.cmp(n2));
     let by_name = defs.into_iter().group_by(|(n, _)| n.clone());
 

--- a/rls-analysis/src/symbol_query.rs
+++ b/rls-analysis/src/symbol_query.rs
@@ -47,7 +47,7 @@ impl SymbolQuery {
 
     pub(crate) fn build_stream<'a, I>(&'a self, fsts: I) -> fst::map::Union<'a>
     where
-        I: Iterator<Item = &'a fst::Map>,
+        I: Iterator<Item = &'a fst::Map<Vec<u8>>>,
     {
         let mut stream = fst::map::OpBuilder::new();
         let automaton = QueryAutomaton { query: &self.query_string, mode: self.mode };


### PR DESCRIPTION
Bumps itertools, fst, and rayon's dependencies, which allows for two
dependencies to be removed from the lockfile.

Slightly alters fst::Map's signature because it is now generic.