### PR TITLE
Bump default integration test message timeout to 30s

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -25,7 +25,7 @@ pub fn fixtures_dir() -> &'static Path {
 ///
 /// Env var `RLS_TEST_WAIT_FOR_AGES` allows super long waiting for CI
 pub fn rls_timeout() -> Duration {
-    Duration::from_secs(if std::env::var("RLS_TEST_WAIT_FOR_AGES").is_ok() { 300 } else { 15 })
+    Duration::from_secs(if std::env::var("RLS_TEST_WAIT_FOR_AGES").is_ok() { 300 } else { 30 })
 }
 
 /// Parse valid LSP stdout into a list of json messages


### PR DESCRIPTION
In case we don't want to introduce another env var to rustc CI script

cc https://github.com/rust-lang/rust/pull/84412

r? @ehuss