### PR TITLE
Mark huge rls-analysis test data files as binary to filter greps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+rls-analysis/test_data/rls-analysis/*.json binary
+rls-analysis/test_data/rust-analysis/*.json binary


### PR DESCRIPTION
When doing a `git grep` (of rls or of rust-lang/rust with
`--recurse-submodules`), if the grep happens to match within the huge
rls-analysis test data files, the resulting multi-megabyte single-line
can cause a text pager to grind to a halt and have trouble scrolling
(especially scrolling backwards).

These test data files are autogenerated and aren't formatted for human
consumption, so mark them as binary, which causes `git grep` to instead
just state that they match without printing the matching "line".