### PR TITLE
bump rustfmt with test resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "rustfmt-config_proc_macro"
 version = "0.2.0"
-source = "git+https://github.com/rust-lang/rustfmt?rev=f87414729fc4f18484ab6456701b4a430e5aafc1#f87414729fc4f18484ab6456701b4a430e5aafc1"
+source = "git+https://github.com/rust-lang/rustfmt?rev=2a3635d5d1218c726ff58af4bc35418836143f69#2a3635d5d1218c726ff58af4bc35418836143f69"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2397,7 +2397,7 @@ dependencies = [
 [[package]]
 name = "rustfmt-nightly"
 version = "1.4.37"
-source = "git+https://github.com/rust-lang/rustfmt?rev=f87414729fc4f18484ab6456701b4a430e5aafc1#f87414729fc4f18484ab6456701b4a430e5aafc1"
+source = "git+https://github.com/rust-lang/rustfmt?rev=2a3635d5d1218c726ff58af4bc35418836143f69#2a3635d5d1218c726ff58af4bc35418836143f69"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ racer = { version = "2.1.46", default-features = false }
 rand = "0.7"
 rayon = "1"
 rustc_tools_util = "0.2"
-rustfmt-nightly = { git = "https://github.com/rust-lang/rustfmt", rev = "f87414729fc4f18484ab6456701b4a430e5aafc1" }
+rustfmt-nightly = { git = "https://github.com/rust-lang/rustfmt", rev = "2a3635d5d1218c726ff58af4bc35418836143f69" }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
Targeting the bump-rustc-ap version as that's what appears to be the target for the submod bump PR in r-l/rust