### PR TITLE
Document that configuration options live in a "rust" object

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Studio Code extension this will be done via the workspace settings file
 
 Other editors will have their own way of sending the
 [workspace/DidChangeConfiguration](https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeConfiguration)
-method.
+method. Options are nested in the `rust` object, so your server might send
+`{"settings":{"rust":{"unstable_features":true}}}` as parameters.
 
 Entries in this file will affect how the RLS operates and how it builds your
 project.


### PR DESCRIPTION
It wasn't obvious to me where to place options for
"didChangeConfiguration", so this could help others.
VSCode adds the prefix automatically when editing settings.json but
I didn't use that.