### PR TITLE
Sync with rustc_span changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,7 +2403,7 @@ dependencies = [
 [[package]]
 name = "rustfmt-config_proc_macro"
 version = "0.2.0"
-source = "git+https://github.com/rust-lang/rustfmt?rev=2a3635d5d1218c726ff58af4bc35418836143f69#2a3635d5d1218c726ff58af4bc35418836143f69"
+source = "git+https://github.com/rust-lang/rustfmt?rev=927561ace1ef9485206a9e6a9482e39fb3e1f31b#927561ace1ef9485206a9e6a9482e39fb3e1f31b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "rustfmt-nightly"
 version = "1.4.37"
-source = "git+https://github.com/rust-lang/rustfmt?rev=2a3635d5d1218c726ff58af4bc35418836143f69#2a3635d5d1218c726ff58af4bc35418836143f69"
+source = "git+https://github.com/rust-lang/rustfmt?rev=927561ace1ef9485206a9e6a9482e39fb3e1f31b#927561ace1ef9485206a9e6a9482e39fb3e1f31b"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ racer = { version = "2.1.46", default-features = false }
 rand = "0.7"
 rayon = "1"
 rustc_tools_util = "0.2"
-rustfmt-nightly = { git = "https://github.com/rust-lang/rustfmt", rev = "2a3635d5d1218c726ff58af4bc35418836143f69" }
+rustfmt-nightly = { git = "https://github.com/rust-lang/rustfmt", rev = "927561ace1ef9485206a9e6a9482e39fb3e1f31b" }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/rls-rustc/src/lib.rs
+++ b/rls-rustc/src/lib.rs
@@ -121,7 +121,7 @@ impl Callbacks for ShimCalls {
         let sess = compiler.session();
         let input = compiler.input();
 
-        let cwd = &sess.working_dir.0;
+        let cwd = &sess.working_dir.local_path_if_available();
 
         let src_path = match input {
             Input::File(ref name) => Some(name.to_path_buf()),
@@ -209,14 +209,14 @@ impl Callbacks for ShimCalls {
 
 #[cfg(feature = "ipc")]
 fn fetch_input_files(sess: &rustc_session::Session) -> Vec<PathBuf> {
-    let cwd = &sess.working_dir.0;
+    let cwd = &sess.working_dir.local_path_if_available();
 
     sess.source_map()
         .files()
         .iter()
         .filter(|fmap| fmap.is_real_file())
         .filter(|fmap| !fmap.is_imported())
-        .map(|fmap| fmap.name.to_string())
+        .map(|fmap| fmap.name.prefer_local().to_string())
         .map(|fmap| src_path(Some(cwd), fmap).unwrap())
         .collect()
 }

--- a/rls/src/build/rustc.rs
+++ b/rls/src/build/rustc.rs
@@ -239,7 +239,7 @@ impl rustc_driver::Callbacks for RlsRustcCalls {
         let input = compiler.input();
         let crate_name = queries.crate_name().unwrap().peek().clone();
 
-        let cwd = &sess.working_dir.0;
+        let cwd = &sess.working_dir.local_path_if_available();
 
         let src_path = match input {
             Input::File(ref name) => Some(name.to_path_buf()),
@@ -327,14 +327,14 @@ fn clippy_config(config: &mut interface::Config) {
 }
 
 fn fetch_input_files(sess: &Session) -> Vec<PathBuf> {
-    let cwd = &sess.working_dir.0;
+    let cwd = &sess.working_dir.local_path_if_available();
 
     sess.source_map()
         .files()
         .iter()
         .filter(|fmap| fmap.is_real_file())
         .filter(|fmap| !fmap.is_imported())
-        .map(|fmap| fmap.name.to_string())
+        .map(|fmap| fmap.name.prefer_local().to_string())
         .map(|fmap| src_path(Some(cwd), fmap).unwrap())
         .collect()
 }


### PR DESCRIPTION
rust-lang/rust#83813 made some changes to SourceMap and RealFileName. Now to get a string from a `rustc_span::FileName` or `RealFileName` (`working_dir` in `rustc_span::Session` is now a `RealFileName` because it may be remapped), we need to specify if we would like the local filesystem path or remapped path via `--remap-path-prefix`.

There are two files affected, the context very similar in both. I'm not entirely sure if we want the local path or remapped path here, so I just picked local path as a placeholder for opening this PR. 

Closes - after updating rls module in rustc repo - https://github.com/rust-lang/rust/issues/85225