### PR TITLE
Update regex use to match test for external librairies

### DIFF
--- a/rls/src/actions/run.rs
+++ b/rls/src/actions/run.rs
@@ -23,7 +23,7 @@ pub fn collect_run_actions(ctx: &InitActionContext, file: &Path) -> Vec<RunActio
     }
 
     lazy_static! {
-        /// __(a):__ `\#\[test\]` matches `#[test]`
+        /// __(a):__ `\#\[([\w]+::)*test\]` matches `#[test]`, `#[async_executor::test]` or `#[async_lib::module::test]`.
         ///
         /// __(b):__ `^[^\/]*?fn\s+(?P<name>\w+)` matches any line which contains `fn name` before any comment is started and captures the word after fn.
         /// The laziness of the quantifier is there to make the regex quicker (about 5 times less steps)
@@ -42,7 +42,7 @@ pub fn collect_run_actions(ctx: &InitActionContext, file: &Path) -> Vec<RunActio
         /// fn right_function() {}
         /// ```
         static ref TEST_FN_RE: Regex =
-            Regex::new(r"(?m)#\[test\](\n|.)*?^[^/]*?fn\s+(?P<name>\w+)").unwrap();
+            Regex::new(r"(?m)#\[([\w]+::)*test\](\n|.)*?^[^/]*?fn\s+(?P<name>\w+)").unwrap();
     }
 
     let line_index = LineIndex::new(&text);

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -987,24 +987,42 @@ fn client_lens_run() {
         },
     );
 
-    let expected = CodeLens {
-        command: Some(Command {
-            command: "rls.run".to_string(),
-            title: "Run test".to_string(),
-            arguments: Some(vec![json!({
-                "args": [ "test", "--", "--nocapture", "test_foo" ],
-                "binary": "cargo",
-                "env": { "RUST_BACKTRACE": "short" }
-            })]),
-        }),
-        data: None,
-        range: Range {
-            start: Position { line: 4, character: 3 },
-            end: Position { line: 4, character: 11 },
+    let expected = vec![
+        CodeLens {
+            command: Some(Command {
+                command: "rls.run".to_string(),
+                title: "Run test".to_string(),
+                arguments: Some(vec![json!({
+                    "args": [ "test", "--", "--nocapture", "test_foo" ],
+                    "binary": "cargo",
+                    "env": { "RUST_BACKTRACE": "short" }
+                })]),
+            }),
+            data: None,
+            range: Range {
+                start: Position { line: 4, character: 3 },
+                end: Position { line: 4, character: 11 },
+            },
         },
-    };
+        CodeLens {
+            command: Some(Command {
+                command: "rls.run".to_string(),
+                title: "Run test".to_string(),
+                arguments: Some(vec![json!({
+                    "args": [ "test", "--", "--nocapture", "test_bar"],
+                    "binary": "cargo",
+                    "env": { "RUST_BACKTRACE": "short" }
+                })]),
+            }),
+            data: None,
+            range: Range {
+                start: Position { line: 9, character: 3 },
+                end: Position { line: 9, character: 11 },
+            },
+        },
+    ];
 
-    assert_eq!(lens, Some(vec![expected]));
+    assert_eq!(lens, Some(expected));
 }
 
 #[test]

--- a/tests/fixtures/lens_run/src/main.rs
+++ b/tests/fixtures/lens_run/src/main.rs
@@ -5,3 +5,13 @@ pub fn main() {
 fn test_foo() {
 
 }
+
+#[tokio::test]
+fn test_bar() {
+
+}
+
+#[dummy_ext]
+fn test_baz() {
+
+}


### PR DESCRIPTION
Make test regex a little bit more permissive.
This will allow external libs that have special test macro to be recognize as valid test case.

For example, following macros will be recognized as valid test case:
```
#[test]
#[tokio::test]
#[async_std::test]
#[actix_web::test]
#[actix_rt::test]
#[actix_web::rt::test]
```

Issue was at beginning reported in `vscode-rust` repo [here](https://github.com/rust-lang/vscode-rust/issues/756) and author switch from `rls` to `rust-analyser`.

Looking at `rust-analyser`, everything that has `test` in function attributes is recognized as a test (see code [here](https://github.com/rust-analyzer/rust-analyzer/blob/2ac1ffc0f3bef98f74b0c3d7ac2371d73c75ce5c/crates/ide_assists/src/utils.rs#L71)).
Running test or not is a choice left to user, even if it does not work perfectly.