### PR TITLE
Only show suggested code when it is non-empty

### DIFF
--- a/rls/src/actions/diagnostics.rs
+++ b/rls/src/actions/diagnostics.rs
@@ -175,7 +175,11 @@ fn format_notes(children: &[AssociatedMessage], primary: &DiagnosticSpan) -> Opt
         } else if spans.len() == 1 && spans[0].is_within(primary) {
             add_message_to_notes!(message);
             if let Some(ref suggested) = spans[0].suggested_replacement {
-                notes.push_str(&format!(": `{}`", suggested));
+                if !suggested.is_empty() {
+                    // Only show the suggestion when it is non-empty.
+                    // This matches rustc's behavior.
+                    notes.push_str(&format!(": `{}`", suggested));
+                }
             }
         }
     }


### PR DESCRIPTION
This is to match rustc's behavior, and to avoid weird diagnostic boxes
that look like this:

    unnecessary trailing semicolons

    note: `#[warn(redundant_semicolons)]` on by default
    help: remove these semicolons: ``

After this change, the last line should look like this:

    help: remove these semicolons
