### PR TITLE
Fix typos “a”→“an”

### DIFF
--- a/rls-ipc/src/rpc.rs
+++ b/rls-ipc/src/rpc.rs
@@ -24,7 +24,7 @@ pub mod file_loader {
         #[rpc(name = "file_exists")]
         fn file_exists(&self, path: PathBuf) -> Result<bool>;
 
-        /// Read the contents of an UTF-8 file into memory.
+        /// Read the contents of a UTF-8 file into memory.
         #[rpc(name = "read_file")]
         fn read_file(&self, path: PathBuf) -> Result<String>;
     }

--- a/rls/src/lsp_data.rs
+++ b/rls/src/lsp_data.rs
@@ -269,7 +269,7 @@ pub struct InitializationOptions {
 }
 
 impl InitializationOptions {
-    /// try to deserialize a Initialization from a json value. If exists,
+    /// try to deserialize an Initialization from a json value. If exists,
     /// val.settings is expected to be a Value::Object containing only one key,
     /// "rust", all first level keys of rust's value are converted to
     /// snake_case, duplicated and unknown keys are reported


### PR DESCRIPTION
See rust-lang/rust#88230