### PR TITLE
Expose public functions from private raw module

### DIFF
--- a/rls-analysis/src/lib.rs
+++ b/rls-analysis/src/lib.rs
@@ -21,7 +21,10 @@ mod util;
 use analysis::Analysis;
 pub use analysis::{Def, Ident, IdentKind, Ref};
 pub use loader::{AnalysisLoader, CargoAnalysisLoader, SearchDirectory, Target};
-pub use raw::{name_space_for_def_kind, read_analysis_from_files, Crate, CrateId, DefKind};
+pub use raw::{
+    deserialize_crate_data, name_space_for_def_kind, read_analysis_from_files, read_crate_data,
+    Crate, CrateId, DefKind,
+};
 pub use symbol_query::SymbolQuery;
 
 use std::collections::HashMap;


### PR DESCRIPTION
Previously, `raw::deserialize_crate_data` and `raw::read_crate_data` functions were make public inside the raw module, but I did not see that the `raw` module itself was not public. I now realize that the functions should also have been exposed in the main library file as public functions on the primary module. This PR addresses that