### PR TITLE
Update rustfmt, pull in a few commits from the `rustup` branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "racer"
-version = "2.1.47"
+version = "2.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513c70e67444a0d62fdc581dffa521c6820942a5f08300d0864863f8d0e750e3"
+checksum = "7fec2e85e7a30f8fd31b7cf288ad363b5e51fd2cb6f53b416b0cfaabd84e1ccb"
 dependencies = [
  "bitflags",
  "clap",
@@ -1950,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_arena"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "526610f47139efa440178239553b59ea805ff57a532b4e295c71d2a9b18fd676"
+checksum = "550ca1a0925d31a0af089b18c89f5adf3b286e319e3e1f1a5204c21bd2f17371"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "smallvec",
@@ -1960,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf6a9dda0804a7243b0282e3b75a8cf4654c7a61f033e587751941e1fe39391b"
+checksum = "4aa53b68080df17994a54747f7c37b0686288a670efb9ba3b382ce62e744aed2"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",
@@ -1977,9 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f5019be8b41a58664169fd2f4b1a37fe82705681db394b76419e4e87d40ab1"
+checksum = "0ae71e68fada466a4b2c39c79ca6aee3226587abe6787170d2f6c92237569565"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_span",
@@ -1988,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a701717fb14549331085756b9741ae3b4bf35808489f1887d72c1d0e0fe52b77"
+checksum = "faa484d6e0ca32d1d82303647275c696f745599b3d97e686f396ceef5b99d7ae"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -2020,9 +2020,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3182ce85e8bfc96443475547f2f5aa2b5e67655d9b88721795f36f0ba9e265a"
+checksum = "5f85ba19cca320ad797e3a29c35cab9bddfff0e7adbde336a436249e54cee7b1"
 dependencies = [
  "annotate-snippets",
  "atty",
@@ -2040,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed033b93270126ef60963c3ebbd0e026bf53b985172b6366c7b0e7881c9d507"
+checksum = "97d538adab96b8b2b1ca9fcd4c8c47d4e23e862a23d1a38b6c15cd8fd52b34b1"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_span",
@@ -2050,21 +2050,21 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ee6531986a205101e09fd143d7bf31897388f33b1814d4bcc45fd62211dca6"
+checksum = "8ad6f13d240944fa8f360d2f3b849a7cadaec75e477829e7dde61e838deda83d"
 
 [[package]]
 name = "rustc-ap-rustc_graphviz"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3398fddc0e23d2db89c036f8952ddf78cadc597f7059752116e69483e164a5b6"
+checksum = "08b3451153cc5828c02cc4f1a0df146d25ac4b3382a112e25fd9d3f5bff15cdc"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca4e27eb5b701f6bbd47d8fc9d242378fca3e4107a519a28415c2989c4a3bd3"
+checksum = "cd39a9f01b442c629bdff5778cb3dd29b7c2ea4afe62d5ab61d216bd1b556692"
 dependencies = [
  "arrayvec",
  "rustc-ap-rustc_macros",
@@ -2073,18 +2073,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786bbfe9d4d5264294c1819dbf1497a2480b583d5eda1ca9ae22e12d6661f5df"
+checksum = "a5de290c44a90e671d2cd730062b9ef73d11155da7e44e7741d633e1e51e616e"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_lint_defs"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2f045e2b999c154ec505d5fea69c994b742f3ebd2f552d11a6c81723921e47"
+checksum = "69570b4beb61088926b131579865bbe70d124d30778c46307a62ec8b310ae462"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_data_structures",
@@ -2097,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27789cd26d6b9e2fdfa68a262a20664d79ca67d31a3886d40fb88ebf6935869c"
+checksum = "86bd877df37f15c5a44d9679d1b5207ebc95f3943fbc336eeac670195ac58610"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dc331f4958350679679e619d63a891e8d5d34ef99087068c89aa9e657d52caa"
+checksum = "02502d8522ba31d0bcad28a78822b68c1b6ba947a2b4aa6a2341b30594379b80"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_ast",
@@ -2129,9 +2129,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_serialize"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a6824a462c4c1a379e911b0faf86d303a54bcf8673d4cc445195085966a4a4"
+checksum = "5f741f8e9aee6323fbe127329490608a5a250cc0072ac91e684ef62518cdb1ff"
 dependencies = [
  "indexmap",
  "smallvec",
@@ -2139,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a782a5f6ada0dbe089c6416ad0104f0b8a8bdb4bd26ea95e5fefaec67aed5e8a"
+checksum = "dba61eca749f4fced4427ad1cc7f23342cfc6527c3bcc624e3aa56abc1f81298"
 dependencies = [
  "bitflags",
  "getopts",
@@ -2161,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a257546cb264b250c7abdb81239bb02f18a274a966211755a3ea89411b122214"
+checksum = "a642e8d6fc883f34e0778e079f8242ac40c6614a6b7a0ef61681333e847f5e62"
 dependencies = [
  "cfg-if 0.1.10",
  "md-5",
@@ -2181,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "718.0.0"
+version = "722.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a72dd689421bcb5750f3ed0dedf367076e714ef0ba56c02ed391b9a8582862"
+checksum = "80feebd8c323b80dd73a395fa7fabba9e2098b6277670ff89c473f618ffa07de"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
+name = "camino"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo"
 version = "0.54.0"
 source = "git+https://github.com/rust-lang/cargo?rev=8dd533662007374412f460b4e442d3f8c193bff9#8dd533662007374412f460b4e442d3f8c193bff9"
@@ -212,18 +221,6 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "700b3731fd7d357223d0000f4dbf1808401b694609035c3c411fbc0cd375c426"
-dependencies = [
- "semver 0.9.0",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714a157da7991e23d90686b9524b9e12e0407a108647f52e9328f4b3d51ac7f"
@@ -231,6 +228,19 @@ dependencies = [
  "cargo-platform 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.11.0",
  "semver-parser 0.10.2",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ae6de944143141f6155a473a6b02f66c7c3f9f47316f802f80204ebfe6e12"
+dependencies = [
+ "camino",
+ "cargo-platform 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 1.0.4",
  "serde",
  "serde_json",
 ]
@@ -279,7 +289,7 @@ dependencies = [
  "cargo_metadata 0.12.3",
  "clippy_utils",
  "if_chain",
- "itertools 0.9.0",
+ "itertools",
  "pulldown-cmark",
  "quine-mc_cluskey",
  "regex-syntax",
@@ -297,7 +307,7 @@ version = "0.1.53"
 source = "git+https://github.com/rust-lang/rust-clippy?rev=a55912c48e4ac08c0ac39a2d562b44699fa20d4d#a55912c48e4ac08c0ac39a2d562b44699fa20d4d"
 dependencies = [
  "if_chain",
- "itertools 0.9.0",
+ "itertools",
  "regex-syntax",
  "rustc-semver",
  "serde",
@@ -579,19 +589,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
 dependencies = [
  "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
-dependencies = [
- "atty",
- "humantime 1.3.0",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1019,15 +1016,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1843,7 +1831,7 @@ dependencies = [
  "futures 0.3.12",
  "heck",
  "home",
- "itertools 0.9.0",
+ "itertools",
  "jsonrpc-core",
  "lazy_static",
  "log",
@@ -1883,7 +1871,7 @@ version = "0.18.2"
 dependencies = [
  "derive-new",
  "fst",
- "itertools 0.9.0",
+ "itertools",
  "json",
  "log",
  "rls-data",
@@ -2257,7 +2245,7 @@ dependencies = [
 [[package]]
 name = "rustfmt-config_proc_macro"
 version = "0.2.0"
-source = "git+https://github.com/rust-lang/rustfmt?rev=28460e1e9aff317fa1bbca95b22421e7ccd7723d#28460e1e9aff317fa1bbca95b22421e7ccd7723d"
+source = "git+https://github.com/rust-lang/rustfmt?rev=a5f85058ac2e3f330bd48dd8de26bf429fc28c30#a5f85058ac2e3f330bd48dd8de26bf429fc28c30"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2266,20 +2254,20 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.4.37"
-source = "git+https://github.com/rust-lang/rustfmt?rev=28460e1e9aff317fa1bbca95b22421e7ccd7723d#28460e1e9aff317fa1bbca95b22421e7ccd7723d"
+version = "1.4.38"
+source = "git+https://github.com/rust-lang/rustfmt?rev=a5f85058ac2e3f330bd48dd8de26bf429fc28c30#a5f85058ac2e3f330bd48dd8de26bf429fc28c30"
 dependencies = [
  "annotate-snippets",
  "anyhow",
  "bytecount",
- "cargo_metadata 0.8.2",
+ "cargo_metadata 0.14.1",
  "derive-new",
  "diff",
  "dirs",
- "env_logger 0.6.2",
+ "env_logger 0.8.4",
  "getopts",
  "ignore",
- "itertools 0.8.2",
+ "itertools",
  "lazy_static",
  "log",
  "regex",
@@ -2335,16 +2323,6 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
- "serde",
-]
-
-[[package]]
-name = "semver"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
@@ -2360,6 +2338,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser 0.10.2",
+ "serde",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+dependencies = [
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ racer = { version = "2.1.48", default-features = false }
 rand = "0.7"
 rayon = "1"
 rustc_tools_util = "0.2"
-rustfmt-nightly = { git = "https://github.com/rust-lang/rustfmt", rev = "28460e1e9aff317fa1bbca95b22421e7ccd7723d" }
+rustfmt-nightly = { git = "https://github.com/rust-lang/rustfmt", rev = "a5f85058ac2e3f330bd48dd8de26bf429fc28c30" }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ lsp-types = { version = "0.60", features = ["proposed"] }
 lazy_static = "1"
 log = "0.4"
 num_cpus = "1"
-racer = { version = "2.1.47", default-features = false }
+racer = { version = "2.1.48", default-features = false }
 rand = "0.7"
 rayon = "1"
 rustc_tools_util = "0.2"

--- a/rls-ipc/src/rpc.rs
+++ b/rls-ipc/src/rpc.rs
@@ -55,15 +55,14 @@ pub mod callbacks {
 /// Build system-agnostic, basic compilation unit
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Deserialize, Serialize)]
 pub struct Crate {
+    /// A crate identifier calculated by rustc that's stable between compilation sessions.
+    pub stable_crate_id: u64,
     /// Crate name
     pub name: String,
     /// Optional path to a crate root
     pub src_path: Option<PathBuf>,
     /// Edition in which a given crate is compiled
     pub edition: Edition,
-    /// From rustc; mainly used to group other properties used to disambiguate a
-    /// given compilation unit.
-    pub disambiguator: (u64, u64),
 }
 
 /// Rust edition

--- a/rls-rustc/src/lib.rs
+++ b/rls-rustc/src/lib.rs
@@ -121,7 +121,7 @@ impl Callbacks for ShimCalls {
         let sess = compiler.session();
         let input = compiler.input();
 
-        let cwd = &sess.working_dir.local_path_if_available();
+        let cwd = &sess.opts.working_dir.local_path_if_available();
 
         let src_path = match input {
             Input::File(ref name) => Some(name.to_path_buf()),
@@ -209,7 +209,7 @@ impl Callbacks for ShimCalls {
 
 #[cfg(feature = "ipc")]
 fn fetch_input_files(sess: &rustc_session::Session) -> Vec<PathBuf> {
-    let cwd = &sess.working_dir.local_path_if_available();
+    let cwd = &sess.opts.working_dir.local_path_if_available();
 
     sess.source_map()
         .files()

--- a/rls-rustc/src/lib.rs
+++ b/rls-rustc/src/lib.rs
@@ -132,7 +132,7 @@ impl Callbacks for ShimCalls {
         let krate = Crate {
             name: queries.crate_name().unwrap().peek().to_owned(),
             src_path,
-            disambiguator: sess.local_crate_disambiguator().to_fingerprint().as_value(),
+            stable_crate_id: sess.local_stable_crate_id().to_u64(),
             edition: match sess.edition() {
                 rustc_span::edition::Edition::Edition2015 => Edition::Edition2015,
                 rustc_span::edition::Edition::Edition2018 => Edition::Edition2018,

--- a/rls/src/build/ipc.rs
+++ b/rls/src/build/ipc.rs
@@ -102,7 +102,7 @@ mod callbacks {
                     rls_ipc::rpc::Edition::Edition2018 => crate::build::plan::Edition::Edition2018,
                     rls_ipc::rpc::Edition::Edition2021 => crate::build::plan::Edition::Edition2021,
                 },
-                disambiguator: krate.disambiguator,
+                stable_crate_id: krate.stable_crate_id,
             }
         }
     }

--- a/rls/src/build/plan.rs
+++ b/rls/src/build/plan.rs
@@ -223,12 +223,11 @@ impl JobQueue {
 /// Build system-agnostic, basic compilation unit
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Deserialize, Serialize)]
 pub struct Crate {
+    /// A crate identifier calculated by rustc that's stable between compilation sessions.
+    pub stable_crate_id: u64,
     pub name: String,
     pub src_path: Option<PathBuf>,
     pub edition: Edition,
-    /// From rustc; mainly used to group other properties used to disambiguate a
-    /// given compilation unit.
-    pub disambiguator: (u64, u64),
 }
 
 // Temporary, until Edition from rustfmt is available

--- a/rls/src/build/rustc.rs
+++ b/rls/src/build/rustc.rs
@@ -250,7 +250,7 @@ impl rustc_driver::Callbacks for RlsRustcCalls {
         let krate = Crate {
             name: crate_name,
             src_path,
-            disambiguator: sess.local_crate_disambiguator().to_fingerprint().as_value(),
+            stable_crate_id: sess.local_stable_crate_id().to_u64(),
             edition: match sess.edition() {
                 RustcEdition::Edition2015 => Edition::Edition2015,
                 RustcEdition::Edition2018 => Edition::Edition2018,

--- a/rls/src/build/rustc.rs
+++ b/rls/src/build/rustc.rs
@@ -239,7 +239,7 @@ impl rustc_driver::Callbacks for RlsRustcCalls {
         let input = compiler.input();
         let crate_name = queries.crate_name().unwrap().peek().clone();
 
-        let cwd = &sess.working_dir.local_path_if_available();
+        let cwd = &sess.opts.working_dir.local_path_if_available();
 
         let src_path = match input {
             Input::File(ref name) => Some(name.to_path_buf()),
@@ -327,7 +327,7 @@ fn clippy_config(config: &mut interface::Config) {
 }
 
 fn fetch_input_files(sess: &Session) -> Vec<PathBuf> {
-    let cwd = &sess.working_dir.local_path_if_available();
+    let cwd = &sess.opts.working_dir.local_path_if_available();
 
     sess.source_map()
         .files()

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-06-07"
+channel = "nightly-2021-10-20"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-05-19"
+channel = "nightly-2021-06-07"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
r? @Xanewok 

Was originally just planning to bump the rustfmt reference to a more recent hash, but seems like some other changes/fixes hadn't made into the master branch either yet and so were pulled in as well