### PR TITLE
Fix expected diagnostic for crate name typo

### DIFF
--- a/tests/client.rs
+++ b/tests/client.rs
@@ -679,7 +679,9 @@ fn client_dependency_typo_and_fix() {
     let diag = rls.wait_for_diagnostics();
     assert_eq!(diag.diagnostics.len(), 1);
     assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::Error));
-    assert!(diag.diagnostics[0].message.contains("no matching package named `auto-cfg`"));
+    assert!(diag.diagnostics[0]
+        .message
+        .contains("no matching package found\nsearched package name: `auto-cfg`"));
 
     let change_manifest = |contents: &str| {
         std::fs::write(root_path.join("Cargo.toml"), contents).unwrap();


### PR DESCRIPTION
This error message recently failed, and prevented RLS from building on beta. Beta has been taken care of, and this PR backports that commit over to the master branch.