### PR TITLE
Bump cargo version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,14 +126,14 @@ dependencies = [
 [[package]]
 name = "cargo"
 version = "0.61.0"
-source = "git+https://github.com/rust-lang/cargo?rev=1c034752de0df744fcd7788fcbca158830b8bf85#1c034752de0df744fcd7788fcbca158830b8bf85"
+source = "git+https://github.com/rust-lang/cargo?rev=d6cdde584a1f15ea086bae922e20fd27f7165431#d6cdde584a1f15ea086bae922e20fd27f7165431"
 dependencies = [
  "anyhow",
  "atty",
  "bytesize",
- "cargo-platform 0.1.2 (git+https://github.com/rust-lang/cargo?rev=1c034752de0df744fcd7788fcbca158830b8bf85)",
+ "cargo-platform 0.1.2 (git+https://github.com/rust-lang/cargo?rev=d6cdde584a1f15ea086bae922e20fd27f7165431)",
  "cargo-util",
- "clap 3.0.7",
+ "clap 3.1.2",
  "crates-io",
  "crossbeam-utils",
  "curl",
@@ -193,7 +193,7 @@ dependencies = [
 [[package]]
 name = "cargo-platform"
 version = "0.1.2"
-source = "git+https://github.com/rust-lang/cargo?rev=1c034752de0df744fcd7788fcbca158830b8bf85#1c034752de0df744fcd7788fcbca158830b8bf85"
+source = "git+https://github.com/rust-lang/cargo?rev=d6cdde584a1f15ea086bae922e20fd27f7165431#d6cdde584a1f15ea086bae922e20fd27f7165431"
 dependencies = [
  "serde",
 ]
@@ -201,7 +201,7 @@ dependencies = [
 [[package]]
 name = "cargo-util"
 version = "0.1.2"
-source = "git+https://github.com/rust-lang/cargo?rev=1c034752de0df744fcd7788fcbca158830b8bf85#1c034752de0df744fcd7788fcbca158830b8bf85"
+source = "git+https://github.com/rust-lang/cargo?rev=d6cdde584a1f15ea086bae922e20fd27f7165431#d6cdde584a1f15ea086bae922e20fd27f7165431"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.7"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
+checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
 dependencies = [
  "atty",
  "bitflags",
@@ -367,7 +367,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "crates-io"
 version = "0.34.0"
-source = "git+https://github.com/rust-lang/cargo?rev=1c034752de0df744fcd7788fcbca158830b8bf85#1c034752de0df744fcd7788fcbca158830b8bf85"
+source = "git+https://github.com/rust-lang/cargo?rev=d6cdde584a1f15ea086bae922e20fd27f7165431#d6cdde584a1f15ea086bae922e20fd27f7165431"
 dependencies = [
  "anyhow",
  "curl",
@@ -2279,9 +2279,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd43cf25c995eb155e5d692ba38185d68860674f54bb29cb458ee05d6de15561"
+checksum = "744e9ed5b352340aa47ce033716991b5589e23781acb97cad37d4ea70560f55b"
 dependencies = [
  "combine",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ rls-vfs = "0.8"
 rls-ipc = { version = "0.1.0", path = "rls-ipc", optional = true }
 
 anyhow = "1.0.26"
-cargo = { git = "https://github.com/rust-lang/cargo", rev = "1c034752de0df744fcd7788fcbca158830b8bf85" }
-cargo-util = { git = "https://github.com/rust-lang/cargo", rev = "1c034752de0df744fcd7788fcbca158830b8bf85" }
+cargo = { git = "https://github.com/rust-lang/cargo", rev = "d6cdde584a1f15ea086bae922e20fd27f7165431" }
+cargo-util = { git = "https://github.com/rust-lang/cargo", rev = "d6cdde584a1f15ea086bae922e20fd27f7165431" }
 cargo_metadata = "0.14"
 clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", version = "0.1.60", optional = true }
 env_logger = "0.9"
@@ -58,7 +58,7 @@ regex = "1"
 ordslice = "0.3"
 crossbeam-channel = "0.5"
 toml = "0.5"
-toml_edit = { version = "0.13.1", features = ["easy"] }
+toml_edit = { version = "0.13.4", features = ["easy"] }
 heck = "0.3"
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.

--- a/rls/src/project_model.rs
+++ b/rls/src/project_model.rs
@@ -7,7 +7,10 @@ use cargo::{
         PackageId, Workspace,
     },
     ops,
-    util::{errors::CargoResult, important_paths::find_root_manifest_for_wd, toml},
+    util::{
+        errors::CargoResult, important_paths::find_root_manifest_for_wd, interning::InternedString,
+        toml,
+    },
     Config,
 };
 use log::warn;
@@ -36,7 +39,7 @@ struct PackageData {
 
 #[derive(Debug)]
 pub struct Dep {
-    pub crate_name: String,
+    pub crate_name: InternedString,
     pub pkg: Package,
 }
 
@@ -103,7 +106,8 @@ impl ProjectModel {
                 let pkg = cargo_packages.get_one(dep_id)?;
                 let lib = pkg.targets().iter().find(|t| t.is_lib());
                 if let Some(lib) = lib {
-                    let crate_name = resolve.extern_crate_name(pkg_id, dep_id, &lib)?;
+                    let (crate_name, _) =
+                        resolve.extern_crate_name_and_dep_name(pkg_id, dep_id, &lib)?;
                     packages[pkg_id_to_pkg[&pkg_id].0]
                         .deps
                         .push(Dep { crate_name, pkg: pkg_id_to_pkg[&dep_id] })


### PR DESCRIPTION
In rust-lang/cargo@7248f4b70da464b9ed7839e0f26110b6664b6ee6,
`cargo::core::resolver::resolve::Resolve::extern_crate_name` was renamed
to `extern_crate_name_and_dep_name` and started to return both extern
crate and dep name. RLS only needs extern crate name at this moment.

Not sure if there is any crate using rls as a libbrary directly. 
I assume no, so I change the type of the pub field `Dep.crate_name`.
If this is not appropriate, I can alternatively keep it as `String`.