### PR TITLE
feat: update lsp_types to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.60.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3edefcd66dde1f7f1df706f46520a3c93adc5ca4bc5747da6621195e894efd"
+checksum = "e8a69d4142d51b208c9fc3cea68b1a7fcef30354e7aa6ccad07250fd8430fc76"
 dependencies = [
  "bitflags",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ env_logger = "0.9"
 home = "0.5.1"
 itertools = "0.10"
 jsonrpc-core = "18"
-lsp-types = { version = "0.60", features = ["proposed"] }
+lsp-types = { version = "0.92", features = ["proposed"] }
 lazy_static = "1"
 log = "0.4"
 num_cpus = "1"

--- a/rls/src/actions/diagnostics.rs
+++ b/rls/src/actions/diagnostics.rs
@@ -141,6 +141,9 @@ pub fn parse_diagnostics(
             source: Some(source.to_owned()),
             message: diagnostic_message,
             related_information,
+            code_description: None,
+            tags: None,
+            data: None,
         };
 
         (file_path, (diagnostic, suggestions))
@@ -193,9 +196,9 @@ fn format_notes(children: &[AssociatedMessage], primary: &DiagnosticSpan) -> Opt
 
 fn severity(level: &str, is_primary_span: bool) -> DiagnosticSeverity {
     match (level, is_primary_span) {
-        (_, false) => DiagnosticSeverity::Information,
-        ("error", _) => DiagnosticSeverity::Error,
-        (..) => DiagnosticSeverity::Warning,
+        (_, false) => DiagnosticSeverity::INFORMATION,
+        ("error", _) => DiagnosticSeverity::ERROR,
+        (..) => DiagnosticSeverity::WARNING,
     }
 }
 

--- a/rls/src/actions/format.rs
+++ b/rls/src/actions/format.rs
@@ -98,8 +98,8 @@ impl Rustfmt {
             .into_iter()
             .map(|item| {
                 // Rustfmt's line indices are 1-based
-                let start_line = u64::from(item.line_number_orig) - 1;
-                let end_line = start_line + u64::from(item.lines_removed);
+                let start_line = item.line_number_orig - 1;
+                let end_line = start_line + item.lines_removed;
 
                 let mut new_text = item.lines.join(newline);
 
@@ -242,7 +242,7 @@ mod tests {
             Rustfmt::Internal.calc_text_edits(input.to_string(), config()).unwrap()
         }
 
-        fn test_case(input: &str, output: Vec<(u64, u64, u64, u64, &str)>) {
+        fn test_case(input: &str, output: Vec<(u32, u32, u32, u32, &str)>) {
             assert_eq!(
                 format(input),
                 output

--- a/rls/src/actions/mod.rs
+++ b/rls/src/actions/mod.rs
@@ -579,7 +579,7 @@ impl FileWatch {
         }
 
         let local = &path[self.project_uri.len()..];
-        local == "/Cargo.lock" || (local == "/target" && kind == FileChangeType::Deleted)
+        local == "/Cargo.lock" || (local == "/target" && kind == FileChangeType::DELETED)
     }
 
     #[inline]
@@ -589,7 +589,7 @@ impl FileWatch {
 
     #[inline]
     pub fn is_relevant_save_doc(&self, did_save: &DidSaveTextDocumentParams) -> bool {
-        self.relevant_change_kind(&did_save.text_document.uri, FileChangeType::Changed)
+        self.relevant_change_kind(&did_save.text_document.uri, FileChangeType::CHANGED)
     }
 }
 
@@ -629,12 +629,13 @@ mod test {
     }
 
     fn change(url: &str) -> FileEvent {
-        FileEvent::new(Url::parse(url).unwrap(), FileChangeType::Changed)
+        FileEvent::new(Url::parse(url).unwrap(), FileChangeType::CHANGED)
     }
 
     fn did_save(url: &str) -> DidSaveTextDocumentParams {
         DidSaveTextDocumentParams {
             text_document: TextDocumentIdentifier::new(Url::parse(url).unwrap()),
+            text: None,
         }
     }
 

--- a/rls/src/actions/post_build.rs
+++ b/rls/src/actions/post_build.rs
@@ -137,7 +137,7 @@ impl PostBuildHandler {
                 Diagnostic {
                     range,
                     message,
-                    severity: Some(DiagnosticSeverity::Error),
+                    severity: Some(DiagnosticSeverity::ERROR),
                     ..Diagnostic::default()
                 },
                 vec![],
@@ -206,10 +206,11 @@ impl PostBuildHandler {
                     .iter()
                     .map(|(diag, _)| diag)
                     .filter(|diag| {
-                        self.show_warnings || diag.severity != Some(DiagnosticSeverity::Warning)
+                        self.show_warnings || diag.severity != Some(DiagnosticSeverity::WARNING)
                     })
                     .cloned()
                     .collect(),
+                version: None,
             };
 
             self.notifier.notify_publish_diagnostics(params);

--- a/rls/src/server/message.rs
+++ b/rls/src/server/message.rs
@@ -74,7 +74,7 @@ impl<R: DefaultResponse> Response for ResponseWithMessage<R> {
             ResponseWithMessage::Response(r) => out.success(id, &r),
             ResponseWithMessage::Warn(s) => {
                 out.notify(Notification::<ShowMessage>::new(ShowMessageParams {
-                    typ: MessageType::Warning,
+                    typ: MessageType::WARNING,
                     message: s,
                 }));
 
@@ -87,7 +87,7 @@ impl<R: DefaultResponse> Response for ResponseWithMessage<R> {
 
 impl DefaultResponse for WorkspaceEdit {
     fn default() -> WorkspaceEdit {
-        WorkspaceEdit { changes: None, document_changes: None }
+        WorkspaceEdit { changes: None, document_changes: None, change_annotations: None }
     }
 }
 
@@ -482,7 +482,7 @@ mod test {
     fn serialize_message_empty_params() {
         #[derive(Debug)]
         enum DummyNotification {}
-        #[derive(Serialize)]
+        #[derive(Serialize, Deserialize)]
         struct EmptyParams {}
 
         impl LSPNotification for DummyNotification {

--- a/rls/src/server/mod.rs
+++ b/rls/src/server/mod.rs
@@ -25,8 +25,9 @@ pub use lsp_types::request::Initialize as InitializeRequest;
 pub use lsp_types::request::Shutdown as ShutdownRequest;
 use lsp_types::{
     CodeActionProviderCapability, CodeLensOptions, CompletionOptions, ExecuteCommandOptions,
-    ImplementationProviderCapability, InitializeParams, InitializeResult, RenameProviderCapability,
-    ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind,
+    HoverProviderCapability, ImplementationProviderCapability, InitializeParams, InitializeResult,
+    OneOf, ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind,
+    WorkDoneProgressOptions,
 };
 use rls_analysis::AnalysisHost;
 use rls_vfs::Vfs;
@@ -89,7 +90,7 @@ pub(crate) fn maybe_notify_unknown_configs<O: Output>(out: &O, unknowns: &[Strin
         first = false;
     }
     out.notify(Notification::<ShowMessage>::new(ShowMessageParams {
-        typ: MessageType::Warning,
+        typ: MessageType::WARNING,
         message: msg,
     }));
 }
@@ -106,7 +107,7 @@ pub(crate) fn maybe_notify_deprecated_configs<O: Output>(out: &O, keys: &[String
         );
 
         out.notify(Notification::<ShowMessage>::new(ShowMessageParams {
-            typ: MessageType::Warning,
+            typ: MessageType::WARNING,
             message,
         }));
     }
@@ -131,7 +132,7 @@ pub(crate) fn maybe_notify_duplicated_configs<O: Output>(
         msg += "; ";
     }
     out.notify(Notification::<ShowMessage>::new(ShowMessageParams {
-        typ: MessageType::Warning,
+        typ: MessageType::WARNING,
         message: format!("Duplicated RLS configuration: {}", msg),
     }));
 }
@@ -176,7 +177,11 @@ impl BlockingRequestAction for InitializeRequest {
         maybe_notify_deprecated_configs(&out, &deprecated);
         maybe_notify_duplicated_configs(&out, &dups);
 
-        let result = InitializeResult { capabilities: server_caps(ctx) };
+        let result = InitializeResult {
+            capabilities: server_caps(ctx),
+            server_info: None,
+            offset_encoding: None,
+        };
 
         // Send response early before `ctx.init` to enforce
         // initialize-response-before-all-other-messages constraint.
@@ -420,22 +425,25 @@ pub enum ServerStateChange {
 fn server_caps(ctx: &ActionContext) -> ServerCapabilities {
     ServerCapabilities {
         text_document_sync: Some(TextDocumentSyncCapability::Kind(
-            TextDocumentSyncKind::Incremental,
+            TextDocumentSyncKind::INCREMENTAL,
         )),
-        hover_provider: Some(true),
+        hover_provider: Some(HoverProviderCapability::Simple(true)),
         completion_provider: Some(CompletionOptions {
             resolve_provider: Some(true),
             trigger_characters: Some(vec![".".to_string(), ":".to_string()]),
+            all_commit_characters: None,
+            work_done_progress_options: WorkDoneProgressOptions { work_done_progress: Some(false) },
+            completion_item: None,
         }),
-        definition_provider: Some(true),
+        definition_provider: Some(OneOf::Left(true)),
         type_definition_provider: None,
         implementation_provider: Some(ImplementationProviderCapability::Simple(true)),
-        references_provider: Some(true),
-        document_highlight_provider: Some(true),
-        document_symbol_provider: Some(true),
-        workspace_symbol_provider: Some(true),
+        references_provider: Some(OneOf::Left(true)),
+        document_highlight_provider: Some(OneOf::Left(true)),
+        document_symbol_provider: Some(OneOf::Left(true)),
+        workspace_symbol_provider: Some(OneOf::Left(true)),
         code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
-        document_formatting_provider: Some(true),
+        document_formatting_provider: Some(OneOf::Left(true)),
         execute_command_provider: Some(ExecuteCommandOptions {
             // We append our pid to the command so that if there are multiple
             // instances of the RLS then they will have unique names for the
@@ -444,14 +452,15 @@ fn server_caps(ctx: &ActionContext) -> ServerCapabilities {
                 format!("rls.applySuggestion-{}", ctx.pid()),
                 format!("rls.deglobImports-{}", ctx.pid()),
             ],
+            work_done_progress_options: WorkDoneProgressOptions { work_done_progress: Some(false) },
         }),
-        rename_provider: Some(RenameProviderCapability::Simple(true)),
+        rename_provider: Some(OneOf::Left(true)),
         color_provider: None,
 
         // These are supported if the `unstable_features` option is set.
         // We'll update these capabilities dynamically when we get config
         // info from the client.
-        document_range_formatting_provider: Some(false),
+        document_range_formatting_provider: Some(OneOf::Left(false)),
 
         code_lens_provider: Some(CodeLensOptions { resolve_provider: Some(false) }),
         document_on_type_formatting_provider: None,
@@ -460,6 +469,13 @@ fn server_caps(ctx: &ActionContext) -> ServerCapabilities {
         folding_range_provider: None,
         workspace: None,
         selection_range_provider: None,
+        document_link_provider: None,
+        declaration_provider: None,
+        call_hierarchy_provider: None,
+        semantic_tokens_provider: None,
+        moniker_provider: None,
+        linked_editing_range_provider: None,
+        experimental: None,
     }
 }
 
@@ -492,9 +508,13 @@ mod test {
                 window: None,
                 text_document: None,
                 experimental: None,
+                general: None,
+                offset_encoding: None,
             },
             trace: Some(lsp_types::TraceOption::Off),
             workspace_folders: None,
+            client_info: None,
+            locale: None,
         }
     }
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -175,10 +175,13 @@ fn client_test_simple_workspace() {
     let count = rls
         .messages()
         .iter()
-        .filter(|msg| msg["method"] == "window/progress")
-        .filter(|msg| msg["params"]["title"] == "Building")
+        .filter(|msg| msg["method"] == "$/progress")
+        .filter(|msg| msg["params"]["value"]["kind"] == "report")
         .filter(|msg| {
-            msg["params"]["message"].as_str().map(|x| x.starts_with("member_")).unwrap_or(false)
+            msg["params"]["value"]["message"]
+                .as_str()
+                .map(|x| x.starts_with("member_"))
+                .unwrap_or(false)
         })
         .count();
     assert_eq!(count, 4);

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -21,12 +21,20 @@ fn initialize_params(root_path: &Path) -> InitializeParams {
         initialization_options: None,
         capabilities: ClientCapabilities {
             workspace: None,
-            window: Some(WindowClientCapabilities { progress: Some(true) }),
+            window: Some(WindowClientCapabilities {
+                work_done_progress: Some(true),
+                show_message: None,
+                show_document: None,
+            }),
             text_document: None,
             experimental: None,
+            general: None,
+            offset_encoding: None,
         },
         trace: None,
         workspace_folders: None,
+        client_info: None,
+        locale: None,
     }
 }
 
@@ -263,7 +271,7 @@ fn client_changing_workspace_lib_retains_diagnostics() {
         }],
         text_document: VersionedTextDocumentIdentifier {
             uri: Url::from_file_path(p.root().join("library/src/lib.rs")).unwrap(),
-            version: Some(0),
+            version: 0,
         },
     });
 
@@ -289,7 +297,7 @@ fn client_changing_workspace_lib_retains_diagnostics() {
         }],
         text_document: VersionedTextDocumentIdentifier {
             uri: Url::from_file_path(p.root().join("library/src/lib.rs")).unwrap(),
-            version: Some(1),
+            version: 1,
         },
     });
 
@@ -366,7 +374,7 @@ fn client_implicit_workspace_pick_up_lib_changes() {
         }],
         text_document: VersionedTextDocumentIdentifier {
             uri: Url::from_file_path(p.root().join("inner/src/lib.rs")).unwrap(),
-            version: Some(0),
+            version: 0,
         },
     });
 
@@ -387,7 +395,7 @@ fn client_implicit_workspace_pick_up_lib_changes() {
         }],
         text_document: VersionedTextDocumentIdentifier {
             uri: Url::from_file_path(p.root().join("inner/src/lib.rs")).unwrap(),
-            version: Some(1),
+            version: 1,
         },
     });
 
@@ -444,7 +452,7 @@ fn client_test_complete_self_crate_name() {
         CompletionParams {
             context: Some(CompletionContext {
                 trigger_character: Some(":".to_string()),
-                trigger_kind: CompletionTriggerKind::TriggerCharacter,
+                trigger_kind: CompletionTriggerKind::TRIGGER_CHARACTER,
             }),
             text_document_position: TextDocumentPositionParams {
                 position: Position::new(2, 32),
@@ -452,6 +460,8 @@ fn client_test_complete_self_crate_name() {
                     uri: Url::from_file_path(p.root().join("library/tests/test.rs")).unwrap(),
                 },
             },
+            work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+            partial_result_params: PartialResultParams { partial_result_token: None },
         },
     );
 
@@ -518,21 +528,29 @@ fn client_completion_suggests_arguments_in_statements() {
             initialization_options: None,
             capabilities: lsp_types::ClientCapabilities {
                 workspace: None,
-                window: Some(WindowClientCapabilities { progress: Some(true) }),
+                window: Some(WindowClientCapabilities {
+                    work_done_progress: Some(true),
+                    show_message: None,
+                    show_document: None,
+                }),
                 text_document: Some(TextDocumentClientCapabilities {
-                    completion: Some(CompletionCapability {
+                    completion: Some(CompletionClientCapabilities {
                         completion_item: Some(CompletionItemCapability {
                             snippet_support: Some(true),
                             ..CompletionItemCapability::default()
                         }),
-                        ..CompletionCapability::default()
+                        ..CompletionClientCapabilities::default()
                     }),
                     ..TextDocumentClientCapabilities::default()
                 }),
                 experimental: None,
+                general: None,
+                offset_encoding: None,
             },
             trace: None,
             workspace_folders: None,
+            client_info: None,
+            locale: None,
         },
     );
 
@@ -544,7 +562,7 @@ fn client_completion_suggests_arguments_in_statements() {
         CompletionParams {
             context: Some(CompletionContext {
                 trigger_character: Some("f".to_string()),
-                trigger_kind: CompletionTriggerKind::TriggerCharacter,
+                trigger_kind: CompletionTriggerKind::TRIGGER_CHARACTER,
             }),
             text_document_position: TextDocumentPositionParams {
                 position: Position::new(3, 41),
@@ -552,6 +570,8 @@ fn client_completion_suggests_arguments_in_statements() {
                     uri: Url::from_file_path(p.root().join("library/tests/test.rs")).unwrap(),
                 },
             },
+            work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+            partial_result_params: PartialResultParams { partial_result_token: None },
         },
     );
 
@@ -612,7 +632,7 @@ fn client_use_statement_completion_doesnt_suggest_arguments() {
         CompletionParams {
             context: Some(CompletionContext {
                 trigger_character: Some(":".to_string()),
-                trigger_kind: CompletionTriggerKind::TriggerCharacter,
+                trigger_kind: CompletionTriggerKind::TRIGGER_CHARACTER,
             }),
             text_document_position: TextDocumentPositionParams {
                 position: Position::new(2, 32),
@@ -620,6 +640,8 @@ fn client_use_statement_completion_doesnt_suggest_arguments() {
                     uri: Url::from_file_path(p.root().join("library/tests/test.rs")).unwrap(),
                 },
             },
+            work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+            partial_result_params: PartialResultParams { partial_result_token: None },
         },
     );
 
@@ -678,7 +700,7 @@ fn client_dependency_typo_and_fix() {
 
     let diag = rls.wait_for_diagnostics();
     assert_eq!(diag.diagnostics.len(), 1);
-    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::Error));
+    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
     assert!(diag.diagnostics[0]
         .message
         .contains("no matching package found\nsearched package name: `auto-cfg`"));
@@ -692,13 +714,13 @@ fn client_dependency_typo_and_fix() {
     rls.notify::<DidChangeWatchedFiles>(DidChangeWatchedFilesParams {
         changes: vec![FileEvent {
             uri: Url::from_file_path(p.root().join("Cargo.toml")).unwrap(),
-            typ: FileChangeType::Changed,
+            typ: FileChangeType::CHANGED,
         }],
     });
 
     let diag = rls.wait_for_diagnostics();
     assert_eq!(diag.diagnostics.len(), 1);
-    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::Error));
+    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
     assert!(diag.diagnostics[0].message.contains("^0.5555"));
 
     // Fix version issue so no error diagnostics occur.
@@ -708,13 +730,13 @@ fn client_dependency_typo_and_fix() {
     rls.notify::<DidChangeWatchedFiles>(DidChangeWatchedFilesParams {
         changes: vec![FileEvent {
             uri: Url::from_file_path(p.root().join("Cargo.toml")).unwrap(),
-            typ: FileChangeType::Changed,
+            typ: FileChangeType::CHANGED,
         }],
     });
 
     let diag = rls.wait_for_diagnostics();
     assert_eq!(
-        diag.diagnostics.iter().find(|d| d.severity == Some(DiagnosticSeverity::Error)),
+        diag.diagnostics.iter().find(|d| d.severity == Some(DiagnosticSeverity::ERROR)),
         None
     );
 }
@@ -749,7 +771,7 @@ fn client_invalid_toml_manifest() {
 
     assert!(diag.uri.as_str().ends_with("invalid_toml/Cargo.toml"));
     assert_eq!(diag.diagnostics.len(), 1);
-    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::Error));
+    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
     assert!(diag.diagnostics[0].message.contains("failed to parse manifest"));
 
     assert_eq!(
@@ -814,7 +836,7 @@ fn client_invalid_member_toml_manifest() {
     assert!(diag.uri.as_str().ends_with("invalid_member_toml/member_a/dodgy_member/Cargo.toml"));
 
     assert_eq!(diag.diagnostics.len(), 1);
-    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::Error));
+    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
     assert!(diag.diagnostics[0].message.contains("failed to load manifest"));
 }
 
@@ -873,7 +895,7 @@ fn client_invalid_member_dependency_resolution() {
         .ends_with("invalid_member_resolution/member_a/dodgy_member/Cargo.toml"));
 
     assert_eq!(diag.diagnostics.len(), 1);
-    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::Error));
+    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
     assert!(diag.diagnostics[0].message.contains("no matching package named `nosuchdep123`"));
 }
 
@@ -901,7 +923,7 @@ fn client_handle_utf16_unit_text_edits() {
     rls.notify::<DidChangeTextDocument>(DidChangeTextDocumentParams {
         text_document: VersionedTextDocumentIdentifier {
             uri: Url::from_file_path(p.root().join("src/some.rs")).unwrap(),
-            version: Some(0),
+            version: 0,
         },
         // "😢" -> ""
         content_changes: vec![TextDocumentContentChangeEvent {
@@ -947,7 +969,11 @@ fn client_format_utf16_range() {
                 tab_size: 4,
                 insert_spaces: true,
                 properties: Default::default(),
+                trim_trailing_whitespace: None,
+                insert_final_newline: None,
+                trim_final_newlines: None,
             },
+            work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
         },
     );
 
@@ -974,6 +1000,8 @@ fn client_lens_run() {
             capabilities: Default::default(),
             trace: None,
             workspace_folders: None,
+            client_info: None,
+            locale: None,
         },
     );
 
@@ -986,6 +1014,8 @@ fn client_lens_run() {
             text_document: TextDocumentIdentifier {
                 uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
             },
+            work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+            partial_result_params: PartialResultParams { partial_result_token: None },
         },
     );
 
@@ -1046,11 +1076,15 @@ fn client_find_definitions() {
             let id = (line_index * 100 + i) as u64;
             let result = rls.request::<GotoDefinition>(
                 id,
-                TextDocumentPositionParams {
-                    position: Position { line: line_index as u64, character: i as u64 },
-                    text_document: TextDocumentIdentifier {
-                        uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
+                GotoDefinitionParams {
+                    text_document_position_params: TextDocumentPositionParams {
+                        position: Position { line: line_index as u32, character: i as u32 },
+                        text_document: TextDocumentIdentifier {
+                            uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
+                        },
                     },
+                    work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+                    partial_result_params: PartialResultParams { partial_result_token: None },
                 },
             );
 
@@ -1161,6 +1195,8 @@ fn client_deglob() {
                 },
                 range: Range { start: Position::new(2, 0), end: Position::new(2, 0) },
                 context: CodeActionContext { diagnostics: vec![], only: None },
+                work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+                partial_result_params: PartialResultParams { partial_result_token: None },
             },
         )
         .expect("No code actions returned for line 2");
@@ -1187,7 +1223,14 @@ fn client_deglob() {
         }
     );
 
-    rls.request::<ExecuteCommand>(200, ExecuteCommandParams { command, arguments });
+    rls.request::<ExecuteCommand>(
+        200,
+        ExecuteCommandParams {
+            command,
+            arguments,
+            work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+        },
+    );
     // Right now the execute command returns an empty response and sends
     // appropriate apply edit request via a side-channel
     let result = rls
@@ -1219,6 +1262,8 @@ fn client_deglob() {
                 },
                 range: Range { start: Position::new(5, 0), end: Position::new(5, 0) },
                 context: CodeActionContext { diagnostics: vec![], only: None },
+                work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+                partial_result_params: PartialResultParams { partial_result_token: None },
             },
         )
         .expect("No code actions returned for line 12");
@@ -1250,7 +1295,14 @@ fn client_deglob() {
         );
     }
 
-    rls.request::<ExecuteCommand>(1200, ExecuteCommandParams { command, arguments });
+    rls.request::<ExecuteCommand>(
+        1200,
+        ExecuteCommandParams {
+            command,
+            arguments,
+            work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+        },
+    );
     // Right now the execute command returns an empty response and sends
     // appropriate apply edit request via a side-channel
     let result = rls
@@ -1399,11 +1451,15 @@ fn client_goto_def() {
 
     let result = rls.request::<GotoDefinition>(
         11,
-        TextDocumentPositionParams {
-            position: Position { line: 12, character: 27 },
-            text_document: TextDocumentIdentifier {
-                uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
+        GotoDefinitionParams {
+            text_document_position_params: TextDocumentPositionParams {
+                position: Position { line: 12, character: 27 },
+                text_document: TextDocumentIdentifier {
+                    uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
+                },
             },
+            work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+            partial_result_params: PartialResultParams { partial_result_token: None },
         },
     );
 
@@ -1435,11 +1491,14 @@ fn client_hover() {
     let result = rls
         .request::<HoverRequest>(
             11,
-            TextDocumentPositionParams {
-                position: Position { line: 12, character: 27 },
-                text_document: TextDocumentIdentifier {
-                    uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
+            HoverParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    position: Position { line: 12, character: 27 },
+                    text_document: TextDocumentIdentifier {
+                        uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
+                    },
                 },
+                work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
             },
         )
         .unwrap();
@@ -1472,11 +1531,14 @@ fn client_hover_after_src_line_change() {
     let result = rls
         .request::<HoverRequest>(
             11,
-            TextDocumentPositionParams {
-                position: world_src_pos,
-                text_document: TextDocumentIdentifier {
-                    uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
+            HoverParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    position: world_src_pos,
+                    text_document: TextDocumentIdentifier {
+                        uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
+                    },
                 },
+                work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
             },
         )
         .unwrap();
@@ -1501,7 +1563,7 @@ fn client_hover_after_src_line_change() {
         }],
         text_document: VersionedTextDocumentIdentifier {
             uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
-            version: Some(2),
+            version: 2,
         },
     });
 
@@ -1510,11 +1572,14 @@ fn client_hover_after_src_line_change() {
     let result = rls
         .request::<HoverRequest>(
             11,
-            TextDocumentPositionParams {
-                position: world_src_pos_after,
-                text_document: TextDocumentIdentifier {
-                    uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
+            HoverParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    position: world_src_pos_after,
+                    text_document: TextDocumentIdentifier {
+                        uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
+                    },
                 },
+                work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
             },
         )
         .unwrap();
@@ -1535,12 +1600,19 @@ fn client_workspace_symbol() {
     rls.wait_for_indexing();
 
     let symbols = rls
-        .request::<WorkspaceSymbol>(42, WorkspaceSymbolParams { query: "nemo".to_owned() })
+        .request::<WorkspaceSymbol>(
+            42,
+            WorkspaceSymbolParams {
+                query: "nemo".to_owned(),
+                partial_result_params: PartialResultParams { partial_result_token: None },
+                work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+            },
+        )
         .unwrap();
 
     let mut nemos = vec![
-        ("src/main.rs", "nemo", SymbolKind::Function, 1, 11, 1, 15, Some("x")),
-        ("src/foo.rs", "nemo", SymbolKind::Module, 0, 4, 0, 8, Some("foo")),
+        ("src/main.rs", "nemo", SymbolKind::FUNCTION, 1, 11, 1, 15, Some("x")),
+        ("src/foo.rs", "nemo", SymbolKind::MODULE, 0, 4, 0, 8, Some("foo")),
     ];
 
     for (file, name, kind, start_l, start_c, end_l, end_c, container_name) in nemos.drain(..) {
@@ -1556,6 +1628,7 @@ fn client_workspace_symbol() {
                 },
             },
             deprecated: None,
+            tags: None,
         };
         dbg!(&sym);
         assert!(symbols.iter().any(|s| *s == sym));
@@ -1576,12 +1649,19 @@ fn client_workspace_symbol_duplicates() {
     rls.wait_for_indexing();
 
     let symbols = rls
-        .request::<WorkspaceSymbol>(42, WorkspaceSymbolParams { query: "Frobnicator".to_owned() })
+        .request::<WorkspaceSymbol>(
+            42,
+            WorkspaceSymbolParams {
+                query: "Frobnicator".to_owned(),
+                partial_result_params: PartialResultParams { partial_result_token: None },
+                work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+            },
+        )
         .unwrap();
 
     let symbol = SymbolInformation {
         name: "Frobnicator".to_string(),
-        kind: SymbolKind::Struct,
+        kind: SymbolKind::STRUCT,
         container_name: Some("a".to_string()),
         location: Location {
             uri: Url::from_file_path(p.root().join("src/shared.rs")).unwrap(),
@@ -1591,6 +1671,7 @@ fn client_workspace_symbol_duplicates() {
             },
         },
         deprecated: None,
+        tags: None,
     };
 
     assert_eq!(symbols, vec![symbol]);
@@ -1619,6 +1700,8 @@ fn client_find_all_refs_test() {
                     position: Position { line: 0, character: 7 },
                 },
                 context: ReferenceContext { include_declaration: true },
+                work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+                partial_result_params: PartialResultParams { partial_result_token: None },
             },
         )
         .unwrap();
@@ -1659,6 +1742,8 @@ fn client_find_all_refs_no_cfg_test() {
                     position: Position { line: 0, character: 7 },
                 },
                 context: ReferenceContext { include_declaration: true },
+                work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+                partial_result_params: PartialResultParams { partial_result_token: None },
             },
         )
         .unwrap();
@@ -1704,11 +1789,15 @@ fn client_highlight() {
     let result = rls
         .request::<DocumentHighlightRequest>(
             42,
-            TextDocumentPositionParams {
-                position: Position { line: 12, character: 27 },
-                text_document: TextDocumentIdentifier {
-                    uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
+            DocumentHighlightParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    position: Position { line: 12, character: 27 },
+                    text_document: TextDocumentIdentifier {
+                        uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
+                    },
                 },
+                work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+                partial_result_params: PartialResultParams { partial_result_token: None },
             },
         )
         .unwrap();
@@ -1748,6 +1837,7 @@ fn client_rename() {
                     },
                 },
                 new_name: "foo".to_owned(),
+                work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
             },
         )
         .unwrap();
@@ -1789,7 +1879,11 @@ fn client_reformat() {
                 tab_size: 4,
                 insert_spaces: true,
                 properties: Default::default(),
+                trim_trailing_whitespace: None,
+                insert_final_newline: None,
+                trim_final_newlines: None,
             },
+            work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
         },
     );
 
@@ -1828,7 +1922,11 @@ fn client_reformat_with_range() {
                 tab_size: 4,
                 insert_spaces: true,
                 properties: Default::default(),
+                trim_trailing_whitespace: None,
+                insert_final_newline: None,
+                trim_final_newlines: None,
             },
+            work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
         },
     );
 
@@ -1901,8 +1999,8 @@ fn client_completion() {
 
     let expected = [
         // FIXME(https://github.com/rust-lang/rls/issues/1205) - empty "     " string
-        ("world", &Some(CompletionItemKind::Variable), &Some("let world = \"     \";".to_string())),
-        ("x", &Some(CompletionItemKind::Field), &Some("x: u64".to_string())),
+        ("world", &Some(CompletionItemKind::VARIABLE), &Some("let world = \"     \";".to_string())),
+        ("x", &Some(CompletionItemKind::FIELD), &Some("x: u64".to_string())),
     ];
 
     let result = rls.request::<Completion>(
@@ -1913,6 +2011,8 @@ fn client_completion() {
                 position: Position { line: 12, character: 30 },
             },
             context: None,
+            work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+            partial_result_params: PartialResultParams { partial_result_token: None },
         },
     );
     let items = completions(result.unwrap());
@@ -1925,6 +2025,8 @@ fn client_completion() {
                 position: Position { line: 15, character: 30 },
             },
             context: None,
+            work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+            partial_result_params: PartialResultParams { partial_result_token: None },
         },
     );
     let items = completions(result.unwrap());
@@ -1944,7 +2046,7 @@ fn client_bin_lib_project() {
 
     assert!(diag.uri.as_str().ends_with("bin_lib/tests/tests.rs"));
     assert_eq!(diag.diagnostics.len(), 1);
-    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::Warning));
+    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::WARNING));
     assert!(diag.diagnostics[0].message.contains("unused variable: `unused_var`"));
 }
 
@@ -1960,7 +2062,7 @@ fn client_infer_lib() {
 
     assert!(diag.uri.as_str().ends_with("src/lib.rs"));
     assert_eq!(diag.diagnostics.len(), 1);
-    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::Warning));
+    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::WARNING));
     assert!(diag.diagnostics[0].message.contains("struct is never constructed: `UnusedLib`"));
 }
 
@@ -2006,9 +2108,13 @@ fn client_find_impls() {
 
     let result = rls.request::<GotoImplementation>(
         1,
-        TextDocumentPositionParams {
-            text_document: TextDocumentIdentifier::new(uri.clone()),
-            position: Position { line: 3, character: 7 }, // "Bar"
+        GotoDefinitionParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier::new(uri.clone()),
+                position: Position { line: 3, character: 7 }, // "Bar"
+            },
+            work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+            partial_result_params: PartialResultParams { partial_result_token: None },
         },
     );
     let expected = [(9, 15, 9, 18), (10, 12, 10, 15)];
@@ -2026,9 +2132,13 @@ fn client_find_impls() {
 
     let result = rls.request::<GotoImplementation>(
         1,
-        TextDocumentPositionParams {
-            text_document: TextDocumentIdentifier::new(uri.clone()),
-            position: Position { line: 6, character: 6 }, // "Super"
+        GotoDefinitionParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier::new(uri.clone()),
+                position: Position { line: 6, character: 6 }, // "Super"
+            },
+            work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+            partial_result_params: PartialResultParams { partial_result_token: None },
         },
     );
     let expected = [(9, 15, 9, 18), (13, 15, 13, 18)];
@@ -2057,7 +2167,7 @@ fn client_features() {
     let diag = rls.wait_for_diagnostics();
 
     assert_eq!(diag.diagnostics.len(), 1);
-    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::Error));
+    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
     let msg = "cannot find struct, variant or union type `Foo` in this scope";
     assert!(diag.diagnostics[0].message.contains(msg));
 }
@@ -2092,9 +2202,9 @@ fn client_no_default_features() {
     let diag = rls.wait_for_diagnostics();
 
     let diagnostics: Vec<_> =
-        diag.diagnostics.iter().filter(|d| d.severity == Some(DiagnosticSeverity::Error)).collect();
+        diag.diagnostics.iter().filter(|d| d.severity == Some(DiagnosticSeverity::ERROR)).collect();
     assert_eq!(diagnostics.len(), 1);
-    assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::Error));
+    assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
     let msg = "cannot find struct, variant or union type `Baz` in this scope";
     assert!(diagnostics[0].message.contains(msg));
 }
@@ -2112,7 +2222,7 @@ fn client_all_targets() {
 
     assert!(diag.uri.as_str().ends_with("bin_lib/tests/tests.rs"));
     assert_eq!(diag.diagnostics.len(), 1);
-    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::Warning));
+    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::WARNING));
     assert!(diag.diagnostics[0].message.contains("unused variable: `unused_var`"));
 }
 
@@ -2141,11 +2251,15 @@ fn client_fail_uninitialized_request() {
 
     rls.request::<GotoDefinition>(
         ID,
-        TextDocumentPositionParams {
-            text_document: TextDocumentIdentifier {
-                uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
+        GotoDefinitionParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: Url::from_file_path(p.root().join("src/main.rs")).unwrap(),
+                },
+                position: Position { line: 0, character: 0 },
             },
-            position: Position { line: 0, character: 0 },
+            work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+            partial_result_params: PartialResultParams { partial_result_token: None },
         },
     );
 
@@ -2186,7 +2300,7 @@ fn client_init_impl(convert_case: fn(&str) -> String) {
     let diag = rls.wait_for_diagnostics();
 
     assert_eq!(diag.diagnostics.len(), 1);
-    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::Error));
+    assert_eq!(diag.diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
     let msg = "cannot find type `PathBuf` in this scope";
     assert!(diag.diagnostics[0].message.contains(msg));
 }

--- a/tests/fixtures/find_impls/src/main.rs
+++ b/tests/fixtures/find_impls/src/main.rs
@@ -12,3 +12,5 @@ impl Eq for Bar {}
 
 impl Sub for Foo {}
 impl Super for Foo {}
+
+fn main() {}

--- a/tests/fixtures/workspace_symbol_duplicates/src/main.rs
+++ b/tests/fixtures/workspace_symbol_duplicates/src/main.rs
@@ -2,3 +2,5 @@
 mod a;
 #[path="shared.rs"]
 mod b;
+
+fn main() {}

--- a/tests/support/client/mod.rs
+++ b/tests/support/client/mod.rs
@@ -265,9 +265,7 @@ impl<T: AsyncRead + AsyncWrite> RlsHandle<T> {
     /// Blocks until the processing (building + indexing) is done by the RLS.
     #[allow(clippy::bool_comparison)]
     pub fn wait_for_indexing(&mut self) {
-        self.wait_for_message(|msg| {
-            msg["params"]["title"] == "Indexing" && msg["params"]["done"] == true
-        });
+        self.wait_for_message(|msg| msg["params"]["value"]["kind"] == "end");
     }
 
     /// Blocks until a "textDocument/publishDiagnostics" message is received.

--- a/tests/support/harness.rs
+++ b/tests/support/harness.rs
@@ -287,13 +287,13 @@ impl Cache {
     pub(crate) fn mk_ls_position(&mut self, src: Src<'_>) -> lsp_types::Position {
         let line = self.get_line(src);
         let col = line.find(src.name).expect(&format!("Line does not contain name {}", src.name));
-        lsp_types::Position::new((src.line - 1) as u64, char_of_byte_index(&line, col) as u64)
+        lsp_types::Position::new((src.line - 1) as u32, char_of_byte_index(&line, col) as u32)
     }
 
     /// Create a range covering the initial position on the line
     ///
     /// The line number uses a 0-based index.
-    pub(crate) fn mk_ls_range_from_line(&mut self, line: u64) -> lsp_types::Range {
+    pub(crate) fn mk_ls_range_from_line(&mut self, line: u32) -> lsp_types::Range {
         lsp_types::Range::new(lsp_types::Position::new(line, 0), lsp_types::Position::new(line, 0))
     }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -179,10 +179,7 @@ impl RlsHandle {
             |stdout| {
                 stdout
                     .to_json_messages()
-                    .filter(|json| {
-                        json["params"]["title"] == "Indexing"
-                            && json["params"]["done"].as_bool().unwrap_or(false)
-                    })
+                    .filter(|json| json["params"]["value"]["kind"] == "end")
                     .count()
                     >= n
             },

--- a/tests/tooltip.rs
+++ b/tests/tooltip.rs
@@ -26,9 +26,9 @@ pub struct Test {
     /// Relative to the project _source_ dir (e.g. relative to $FIXTURES_DIR/hover/src)
     pub file: String,
     /// One-based line number
-    pub line: u64,
+    pub line: u32,
     /// One-based column number
-    pub col: u64,
+    pub col: u32,
 }
 
 impl Test {
@@ -75,7 +75,7 @@ impl TestResult {
 }
 
 impl Test {
-    pub fn new(file: &str, line: u64, col: u64) -> Test {
+    pub fn new(file: &str, line: u32, col: u32) -> Test {
         Test { file: file.into(), line, col }
     }
 
@@ -86,7 +86,7 @@ impl Test {
     fn run(&self, project_dir: &Path, ctx: &InitActionContext) -> TestResult {
         let url = Url::from_file_path(project_dir.join("src").join(&self.file)).expect(&self.file);
         let doc_id = TextDocumentIdentifier::new(url);
-        let position = Position::new(self.line - 1u64, self.col - 1u64);
+        let position = Position::new(self.line - 1, self.col - 1);
         let params = TextDocumentPositionParams::new(doc_id, position);
         let result = tooltip(&ctx, &params)
             .map_err(|e| format!("tooltip error: {:?}", e))


### PR DESCRIPTION
- [feat: update lsp_types to the latest version](https://github.com/rust-lang/rls/pull/1768/commits/ce33a45ec7eee484c1f3ae1d3a4428ffbd9db4e4)[](https://github.com/aminya):
	- This required adding some optional fields
 	- Updating the progress reporter
 	- Using u32 in some places instead of u64
 	- Passing the correct type as the request/response 
 	- Changing the enum field cases to upper case

