### PR TITLE
Fix an incorrect URL

### DIFF
--- a/rls-span/src/compiler.rs
+++ b/rls-span/src/compiler.rs
@@ -1,6 +1,6 @@
 ///! These are the structures emitted by the compiler as part of JSON errors.
 ///! The original source can be found at
-///! https://github.com/rust-lang/rust/blob/master/src/librustc_errors/json.rs
+///! https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/json.rs
 use std::path::PathBuf;
 
 #[cfg(feature = "derive")]


### PR DESCRIPTION
Follow up https://github.com/rust-lang/rust/pull/74862.

https://github.com/rust-lang/rust/blob/master/src/librustc_errors/json.rs returns page not found.
This PR fixes the incorrect URL.