### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,13 +117,13 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.63.0"
-source = "git+https://github.com/rust-lang/cargo?rev=3f052d8eed98c6a24f8b332fb2e6e6249d12d8c1#3f052d8eed98c6a24f8b332fb2e6e6249d12d8c1"
+version = "0.65.0"
+source = "git+https://github.com/rust-lang/cargo?rev=5514f1e0e1b3650ed8a78306198e90b66b292693#5514f1e0e1b3650ed8a78306198e90b66b292693"
 dependencies = [
  "anyhow",
  "atty",
  "bytesize",
- "cargo-platform 0.1.2 (git+https://github.com/rust-lang/cargo?rev=3f052d8eed98c6a24f8b332fb2e6e6249d12d8c1)",
+ "cargo-platform 0.1.2 (git+https://github.com/rust-lang/cargo?rev=5514f1e0e1b3650ed8a78306198e90b66b292693)",
  "cargo-util",
  "clap",
  "crates-io",
@@ -151,6 +151,7 @@ dependencies = [
  "libgit2-sys",
  "log",
  "memchr",
+ "num_cpus",
  "opener",
  "os_info",
  "pathdiff",
@@ -186,15 +187,15 @@ dependencies = [
 [[package]]
 name = "cargo-platform"
 version = "0.1.2"
-source = "git+https://github.com/rust-lang/cargo?rev=3f052d8eed98c6a24f8b332fb2e6e6249d12d8c1#3f052d8eed98c6a24f8b332fb2e6e6249d12d8c1"
+source = "git+https://github.com/rust-lang/cargo?rev=5514f1e0e1b3650ed8a78306198e90b66b292693#5514f1e0e1b3650ed8a78306198e90b66b292693"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-util"
-version = "0.1.3"
-source = "git+https://github.com/rust-lang/cargo?rev=3f052d8eed98c6a24f8b332fb2e6e6249d12d8c1#3f052d8eed98c6a24f8b332fb2e6e6249d12d8c1"
+version = "0.2.1"
+source = "git+https://github.com/rust-lang/cargo?rev=5514f1e0e1b3650ed8a78306198e90b66b292693#5514f1e0e1b3650ed8a78306198e90b66b292693"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -242,16 +243,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.2"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
+checksum = "8e538f9ee5aa3b3963f09a997035f883677966ed50fce0292611927ce6f6d8c6"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
  "lazy_static",
- "os_str_bytes",
  "strsim",
  "termcolor",
  "textwrap",
@@ -259,15 +260,24 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "a7f98063cac4652f23ccda556b8d04347a7fc4b2cff1f7577cc8c6546e0d8078"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -354,7 +364,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "crates-io"
 version = "0.34.0"
-source = "git+https://github.com/rust-lang/cargo?rev=3f052d8eed98c6a24f8b332fb2e6e6249d12d8c1#3f052d8eed98c6a24f8b332fb2e6e6249d12d8c1"
+source = "git+https://github.com/rust-lang/cargo?rev=5514f1e0e1b3650ed8a78306198e90b66b292693#5514f1e0e1b3650ed8a78306198e90b66b292693"
 dependencies = [
  "anyhow",
  "curl",
@@ -431,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.41"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc6d233563261f8db6ffb83bbaad5a73837a6e6b28868e926337ebbdece0be3"
+checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
 dependencies = [
  "curl-sys",
  "libc",
@@ -446,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.51+curl-7.80.0"
+version = "0.4.56+curl-7.83.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d130987e6a6a34fe0889e1083022fa48cd90e6709a84be3fb8dd95801de5af20"
+checksum = "6093e169dd4de29e468fa649fbae11cdcd5551c81fe5bf1b0677adad7ef3d26f"
 dependencies = [
  "cc",
  "libc",
@@ -1333,9 +1343,9 @@ checksum = "dd20eec3dbe4376829cb7d80ae6ac45e0a766831dca50202ff2d40db46a8a024"
 
 [[package]]
 name = "os_info"
-version = "3.1.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198e392be7e882f0c2836f425e430f81d9a0e99651e4646311347417cddbfd43"
+checksum = "5209b2162b2c140df493a93689e04f8deab3a67634f5bc7a553c0a98e5b8d399"
 dependencies = [
  "log",
  "serde",
@@ -1347,9 +1357,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "parity-tokio-ipc"
@@ -2110,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
 dependencies = [
  "filetime",
  "libc",
@@ -2154,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ rls-vfs = "0.8"
 rls-ipc = { version = "0.1.0", path = "rls-ipc", optional = true }
 
 anyhow = "1.0.26"
-cargo = { git = "https://github.com/rust-lang/cargo", rev = "3f052d8eed98c6a24f8b332fb2e6e6249d12d8c1" }
-cargo-util = { git = "https://github.com/rust-lang/cargo", rev = "3f052d8eed98c6a24f8b332fb2e6e6249d12d8c1" }
+cargo = { git = "https://github.com/rust-lang/cargo", rev = "5514f1e0e1b3650ed8a78306198e90b66b292693" }
+cargo-util = { git = "https://github.com/rust-lang/cargo", rev = "5514f1e0e1b3650ed8a78306198e90b66b292693" }
 cargo_metadata = "0.14"
 clippy_lints = { git = "https://github.com/rust-lang/rust-clippy", version = "0.1.60", optional = true }
 env_logger = "0.9"

--- a/rls/src/build/cargo.rs
+++ b/rls/src/build/cargo.rs
@@ -608,7 +608,7 @@ struct CargoOptions {
     all_features: bool,
     no_default_features: bool,
     features: Vec<String>,
-    jobs: Option<u32>,
+    jobs: Option<i32>,
     all_targets: bool,
 }
 

--- a/rls/src/config.rs
+++ b/rls/src/config.rs
@@ -145,7 +145,7 @@ pub struct Config {
     pub features: Vec<String>,
     pub all_features: bool,
     pub no_default_features: bool,
-    pub jobs: Option<u32>,
+    pub jobs: Option<i32>,
     pub all_targets: bool,
     /// Enables use of Racer for `textDocument/completion` requests.
     ///


### PR DESCRIPTION
Updates to the latest cargo.  The type of jobs switched from u32 to i32 in https://github.com/rust-lang/cargo/pull/10844.